### PR TITLE
Optimize `SyncMap` and Update Benchmarks

### DIFF
--- a/collections/benchmarks.md
+++ b/collections/benchmarks.md
@@ -13,84 +13,84 @@ The following results were recorded on an _M4 Macbook Pro_, using 8 threads and
 100,000 entries for each benchmark:
 
 - `SyncMap` **get()** speed is...
-  - 47.7% **FASTER** than `ConcurrentHashMap` for an empty map.
-  - 48.5% **FASTER** than `ConcurrentHashMap` for a presized empty map.
-  - 18.9% **SLOWER** than `ConcurrentHashMap` for a full map.
+  - 47.8% **FASTER** than `ConcurrentHashMap` for an empty map.
+  - 48.1% **FASTER** than `ConcurrentHashMap` for a presized empty map.
+  - 21.0% **FASTER** than `ConcurrentHashMap` for a full map.
 
 - `SyncMap` **put()** speed is...
-  - 16.3% **FASTER** than `ConcurrentHashMap` for an empty map.
-  - 19.6% **SLOWER** than `ConcurrentHashMap` for a presized empty map.
-  - 37.8% **FASTER** than `ConcurrentHashMap` for a full map.
+  - 23.8% **FASTER** than `ConcurrentHashMap` for an empty map.
+  - 14.5% **SLOWER** than `ConcurrentHashMap` for a presized empty map.
+  - 32.0% **FASTER** than `ConcurrentHashMap` for a full map.
 
 - `SyncMap` **put()** then **get()** speed is...
-  - 127.0% **FASTER** than `ConcurrentHashMap` for an empty map.
-  - 68.6% **FASTER** than `ConcurrentHashMap` for a presized empty map.
-  - 56.7% **FASTER** than `ConcurrentHashMap` for a full map.
+  - 109.7% **FASTER** than `ConcurrentHashMap` for an empty map.
+  - 70.4% **FASTER** than `ConcurrentHashMap` for a presized empty map.
+  - 55.1% **FASTER** than `ConcurrentHashMap` for a full map.
 
 ### Results
 
 ```txt
 Benchmark                   (implementation)       (mode)  (prime)  (readPercentage)  (size)   Mode  Cnt  Score   Error   Units
-SyncMapBenchmark.get_only            SyncMap         none    false                50  100000  thrpt    5  2.408 ± 0.029  ops/ns
-SyncMapBenchmark.get_only            SyncMap         none     true                50  100000  thrpt    5  2.410 ± 0.004  ops/ns
-SyncMapBenchmark.get_only            SyncMap      presize    false                50  100000  thrpt    5  2.413 ± 0.006  ops/ns
-SyncMapBenchmark.get_only            SyncMap      presize     true                50  100000  thrpt    5  2.405 ± 0.014  ops/ns
-SyncMapBenchmark.get_only            SyncMap  prepopulate    false                50  100000  thrpt    5  1.922 ± 0.014  ops/ns
-SyncMapBenchmark.get_only            SyncMap  prepopulate     true                50  100000  thrpt    5  1.932 ± 0.030  ops/ns
+SyncMapBenchmark.get_only            SyncMap         none    false                50  100000  thrpt    5  2.411 ± 0.004  ops/ns
+SyncMapBenchmark.get_only            SyncMap         none     true                50  100000  thrpt    5  2.405 ± 0.006  ops/ns
+SyncMapBenchmark.get_only            SyncMap      presize    false                50  100000  thrpt    5  2.416 ± 0.006  ops/ns
+SyncMapBenchmark.get_only            SyncMap      presize     true                50  100000  thrpt    5  2.398 ± 0.003  ops/ns
+SyncMapBenchmark.get_only            SyncMap  prepopulate    false                50  100000  thrpt    5  1.928 ± 0.024  ops/ns
+SyncMapBenchmark.get_only            SyncMap  prepopulate     true                50  100000  thrpt    5  1.948 ± 0.035  ops/ns
 
-SyncMapBenchmark.get_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  1.630 ± 0.002  ops/ns
-SyncMapBenchmark.get_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  2.403 ± 0.017  ops/ns
-SyncMapBenchmark.get_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  1.625 ± 0.002  ops/ns
-SyncMapBenchmark.get_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  2.408 ± 0.001  ops/ns
-SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  2.379 ± 0.020  ops/ns
-SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  2.382 ± 0.012  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  1.631 ± 0.002  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  2.418 ± 0.002  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  1.631 ± 0.004  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  2.414 ± 0.001  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  1.593 ± 0.004  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  2.372 ± 0.049  ops/ns
 
-SyncMapBenchmark.get_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.025 ± 0.002  ops/ns
-SyncMapBenchmark.get_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.025 ± 0.003  ops/ns
-SyncMapBenchmark.get_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.026 ± 0.005  ops/ns
-SyncMapBenchmark.get_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.032 ± 0.052  ops/ns
-SyncMapBenchmark.get_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.030 ± 0.045  ops/ns
-SyncMapBenchmark.get_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.024 ± 0.001  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.026 ± 0.005  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.027 ± 0.006  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.034 ± 0.044  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.031 ± 0.043  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.026 ± 0.007  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.026 ± 0.006  ops/ns
 
-SyncMapBenchmark.get_put             SyncMap         none    false                50  100000  thrpt    5  0.527 ± 0.031  ops/ns
-SyncMapBenchmark.get_put             SyncMap         none     true                50  100000  thrpt    5  0.547 ± 0.071  ops/ns
-SyncMapBenchmark.get_put             SyncMap      presize    false                50  100000  thrpt    5  0.570 ± 0.089  ops/ns
-SyncMapBenchmark.get_put             SyncMap      presize     true                50  100000  thrpt    5  0.539 ± 0.120  ops/ns
-SyncMapBenchmark.get_put             SyncMap  prepopulate    false                50  100000  thrpt    5  0.520 ± 0.019  ops/ns
-SyncMapBenchmark.get_put             SyncMap  prepopulate     true                50  100000  thrpt    5  0.528 ± 0.043  ops/ns
+SyncMapBenchmark.get_put             SyncMap         none    false                50  100000  thrpt    5  0.534 ± 0.053  ops/ns
+SyncMapBenchmark.get_put             SyncMap         none     true                50  100000  thrpt    5  0.539 ± 0.064  ops/ns
+SyncMapBenchmark.get_put             SyncMap      presize    false                50  100000  thrpt    5  0.532 ± 0.042  ops/ns
+SyncMapBenchmark.get_put             SyncMap      presize     true                50  100000  thrpt    5  0.542 ± 0.041  ops/ns
+SyncMapBenchmark.get_put             SyncMap  prepopulate    false                50  100000  thrpt    5  0.526 ± 0.047  ops/ns
+SyncMapBenchmark.get_put             SyncMap  prepopulate     true                50  100000  thrpt    5  0.517 ± 0.025  ops/ns
 
-SyncMapBenchmark.get_put   ConcurrentHashMap         none    false                50  100000  thrpt    5  0.253 ± 0.096  ops/ns
-SyncMapBenchmark.get_put   ConcurrentHashMap         none     true                50  100000  thrpt    5  0.241 ± 0.005  ops/ns
-SyncMapBenchmark.get_put   ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.338 ± 0.030  ops/ns
-SyncMapBenchmark.get_put   ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.320 ± 0.017  ops/ns
-SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.357 ± 0.044  ops/ns
-SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.337 ± 0.015  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap         none    false                50  100000  thrpt    5  0.241 ± 0.002  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap         none     true                50  100000  thrpt    5  0.257 ± 0.006  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.329 ± 0.040  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.318 ± 0.006  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.339 ± 0.095  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.349 ± 0.022  ops/ns
 
-SyncMapBenchmark.get_put     SynchronizedMap         none    false                50  100000  thrpt    5  0.018 ± 0.012  ops/ns
-SyncMapBenchmark.get_put     SynchronizedMap         none     true                50  100000  thrpt    5  0.018 ± 0.015  ops/ns
-SyncMapBenchmark.get_put     SynchronizedMap      presize    false                50  100000  thrpt    5  0.018 ± 0.012  ops/ns
-SyncMapBenchmark.get_put     SynchronizedMap      presize     true                50  100000  thrpt    5  0.019 ± 0.013  ops/ns
-SyncMapBenchmark.get_put     SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.019 ± 0.013  ops/ns
-SyncMapBenchmark.get_put     SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.019 ± 0.010  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap         none    false                50  100000  thrpt    5  0.020 ± 0.002  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap         none     true                50  100000  thrpt    5  0.020 ± 0.009  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap      presize    false                50  100000  thrpt    5  0.021 ± 0.003  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap      presize     true                50  100000  thrpt    5  0.018 ± 0.013  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.019 ± 0.012  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.019 ± 0.014  ops/ns
 
-SyncMapBenchmark.put_only            SyncMap         none    false                50  100000  thrpt    5  0.222 ± 0.027  ops/ns
-SyncMapBenchmark.put_only            SyncMap         none     true                50  100000  thrpt    5  0.235 ± 0.041  ops/ns
-SyncMapBenchmark.put_only            SyncMap      presize    false                50  100000  thrpt    5  0.238 ± 0.012  ops/ns
-SyncMapBenchmark.put_only            SyncMap      presize     true                50  100000  thrpt    5  0.230 ± 0.019  ops/ns
-SyncMapBenchmark.put_only            SyncMap  prepopulate    false                50  100000  thrpt    5  0.232 ± 0.052  ops/ns
-SyncMapBenchmark.put_only            SyncMap  prepopulate     true                50  100000  thrpt    5  0.412 ± 0.048  ops/ns
+SyncMapBenchmark.put_only            SyncMap         none    false                50  100000  thrpt    5  0.255 ± 0.027  ops/ns
+SyncMapBenchmark.put_only            SyncMap         none     true                50  100000  thrpt    5  0.242 ± 0.014  ops/ns
+SyncMapBenchmark.put_only            SyncMap      presize    false                50  100000  thrpt    5  0.213 ± 0.017  ops/ns
+SyncMapBenchmark.put_only            SyncMap      presize     true                50  100000  thrpt    5  0.265 ± 0.012  ops/ns
+SyncMapBenchmark.put_only            SyncMap  prepopulate    false                50  100000  thrpt    5  0.239 ± 0.015  ops/ns
+SyncMapBenchmark.put_only            SyncMap  prepopulate     true                50  100000  thrpt    5  0.408 ± 0.053  ops/ns
 
-SyncMapBenchmark.put_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  0.237 ± 0.257  ops/ns
-SyncMapBenchmark.put_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  0.202 ± 0.171  ops/ns
-SyncMapBenchmark.put_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.300 ± 0.029  ops/ns
-SyncMapBenchmark.put_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.286 ± 0.040  ops/ns
-SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.309 ± 0.044  ops/ns
-SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.299 ± 0.029  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  0.206 ± 0.219  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  0.160 ± 0.025  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.273 ± 0.029  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.310 ± 0.047  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.313 ± 0.022  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.309 ± 0.027  ops/ns
 
-SyncMapBenchmark.put_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.024 ± 0.026  ops/ns
-SyncMapBenchmark.put_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.029 ± 0.042  ops/ns
-SyncMapBenchmark.put_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.021 ± 0.006  ops/ns
-SyncMapBenchmark.put_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.021 ± 0.005  ops/ns
-SyncMapBenchmark.put_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.026 ± 0.032  ops/ns
-SyncMapBenchmark.put_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.027 ± 0.032  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.032 ± 0.040  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.023 ± 0.016  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.025 ± 0.019  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.026 ± 0.025  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.021 ± 0.001  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.022 ± 0.004  ops/ns
 ```

--- a/collections/benchmarks.md
+++ b/collections/benchmarks.md
@@ -13,74 +13,84 @@ The following results were recorded on an _M4 Macbook Pro_, using 8 threads and
 100,000 entries for each benchmark:
 
 - `SyncMap` **get()** speed is...
-  - 4.1% **SLOWER** than `ConcurrentHashMap` for an empty map.
-  - 3.9% **SLOWER** than `ConcurrentHashMap` for a presized empty map.
-  - 6.7% **SLOWER** than `ConcurrentHashMap` for a full map.
+  - 47.7% **FASTER** than `ConcurrentHashMap` for an empty map.
+  - 48.5% **FASTER** than `ConcurrentHashMap` for a presized empty map.
+  - 18.9% **SLOWER** than `ConcurrentHashMap` for a full map.
 
 - `SyncMap` **put()** speed is...
-  - 44.8% **FASTER** than `ConcurrentHashMap` for an empty map.
-  - 30.0% **SLOWER** than `ConcurrentHashMap` for a presized empty map.
-  - 53.9% **FASTER** than `ConcurrentHashMap` for a full map.
+  - 16.3% **FASTER** than `ConcurrentHashMap` for an empty map.
+  - 19.6% **SLOWER** than `ConcurrentHashMap` for a presized empty map.
+  - 37.8% **FASTER** than `ConcurrentHashMap` for a full map.
 
 - `SyncMap` **put()** then **get()** speed is...
-  - 135.6% **FASTER** than `ConcurrentHashMap` for an empty map.
-  - 66.1% **FASTER** than `ConcurrentHashMap` for a presized empty map.
-  - 86.0% **FASTER** than `ConcurrentHashMap` for a full map.
-
-- `SyncMap` random **put()** and **get()** speed is...
-  - 39.1% **FASTER** than `ConcurrentHashMap` for an empty map.
-  - 38.1% **FASTER** than `ConcurrentHashMap` for a presized empty map.
-  - 37.0% **FASTER** than `ConcurrentHashMap` for a full map.
+  - 127.0% **FASTER** than `ConcurrentHashMap` for an empty map.
+  - 68.6% **FASTER** than `ConcurrentHashMap` for a presized empty map.
+  - 56.7% **FASTER** than `ConcurrentHashMap` for a full map.
 
 ### Results
 
 ```txt
-Benchmark                          (implementation)       (mode)   Mode  Cnt  Score   Error   Units
-SyncMapBenchmark.getOnly          ConcurrentHashMap         none  thrpt    5  2.954 ± 0.016  ops/ns
-SyncMapBenchmark.getOnly          ConcurrentHashMap      presize  thrpt    5  2.936 ± 0.005  ops/ns
-SyncMapBenchmark.getOnly          ConcurrentHashMap  prepopulate  thrpt    5  2.658 ± 0.011  ops/ns
+Benchmark                   (implementation)       (mode)  (prime)  (readPercentage)  (size)   Mode  Cnt  Score   Error   Units
+SyncMapBenchmark.get_only            SyncMap         none    false                50  100000  thrpt    5  2.408 ± 0.029  ops/ns
+SyncMapBenchmark.get_only            SyncMap         none     true                50  100000  thrpt    5  2.410 ± 0.004  ops/ns
+SyncMapBenchmark.get_only            SyncMap      presize    false                50  100000  thrpt    5  2.413 ± 0.006  ops/ns
+SyncMapBenchmark.get_only            SyncMap      presize     true                50  100000  thrpt    5  2.405 ± 0.014  ops/ns
+SyncMapBenchmark.get_only            SyncMap  prepopulate    false                50  100000  thrpt    5  1.922 ± 0.014  ops/ns
+SyncMapBenchmark.get_only            SyncMap  prepopulate     true                50  100000  thrpt    5  1.932 ± 0.030  ops/ns
 
-SyncMapBenchmark.getOnly                    SyncMap         none  thrpt    5  2.833 ± 0.018  ops/ns
-SyncMapBenchmark.getOnly                    SyncMap      presize  thrpt    5  2.821 ± 0.004  ops/ns
-SyncMapBenchmark.getOnly                    SyncMap  prepopulate  thrpt    5  2.479 ± 0.021  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  1.630 ± 0.002  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  2.403 ± 0.017  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  1.625 ± 0.002  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  2.408 ± 0.001  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  2.379 ± 0.020  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  2.382 ± 0.012  ops/ns
 
-SyncMapBenchmark.getOnly            SynchronizedMap         none  thrpt    5  0.033 ± 0.045  ops/ns
-SyncMapBenchmark.getOnly            SynchronizedMap      presize  thrpt    5  0.027 ± 0.004  ops/ns
-SyncMapBenchmark.getOnly            SynchronizedMap  prepopulate  thrpt    5  0.035 ± 0.045  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.025 ± 0.002  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.025 ± 0.003  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.026 ± 0.005  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.032 ± 0.052  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.030 ± 0.045  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.024 ± 0.001  ops/ns
 
-SyncMapBenchmark.putAndGet                  SyncMap         none  thrpt    5  0.391 ± 0.066  ops/ns
-SyncMapBenchmark.putAndGet                  SyncMap      presize  thrpt    5  0.427 ± 0.039  ops/ns
-SyncMapBenchmark.putAndGet                  SyncMap  prepopulate  thrpt    5  0.424 ± 0.020  ops/ns
+SyncMapBenchmark.get_put             SyncMap         none    false                50  100000  thrpt    5  0.527 ± 0.031  ops/ns
+SyncMapBenchmark.get_put             SyncMap         none     true                50  100000  thrpt    5  0.547 ± 0.071  ops/ns
+SyncMapBenchmark.get_put             SyncMap      presize    false                50  100000  thrpt    5  0.570 ± 0.089  ops/ns
+SyncMapBenchmark.get_put             SyncMap      presize     true                50  100000  thrpt    5  0.539 ± 0.120  ops/ns
+SyncMapBenchmark.get_put             SyncMap  prepopulate    false                50  100000  thrpt    5  0.520 ± 0.019  ops/ns
+SyncMapBenchmark.get_put             SyncMap  prepopulate     true                50  100000  thrpt    5  0.528 ± 0.043  ops/ns
 
-SyncMapBenchmark.putAndGet        ConcurrentHashMap         none  thrpt    5  0.166 ± 0.113  ops/ns
-SyncMapBenchmark.putAndGet        ConcurrentHashMap      presize  thrpt    5  0.257 ± 0.030  ops/ns
-SyncMapBenchmark.putAndGet        ConcurrentHashMap  prepopulate  thrpt    5  0.228 ± 0.064  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap         none    false                50  100000  thrpt    5  0.253 ± 0.096  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap         none     true                50  100000  thrpt    5  0.241 ± 0.005  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.338 ± 0.030  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.320 ± 0.017  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.357 ± 0.044  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.337 ± 0.015  ops/ns
 
-SyncMapBenchmark.putAndGet          SynchronizedMap         none  thrpt    5  0.012 ± 0.002  ops/ns
-SyncMapBenchmark.putAndGet          SynchronizedMap      presize  thrpt    5  0.012 ± 0.003  ops/ns
-SyncMapBenchmark.putAndGet          SynchronizedMap  prepopulate  thrpt    5  0.012 ± 0.007  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap         none    false                50  100000  thrpt    5  0.018 ± 0.012  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap         none     true                50  100000  thrpt    5  0.018 ± 0.015  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap      presize    false                50  100000  thrpt    5  0.018 ± 0.012  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap      presize     true                50  100000  thrpt    5  0.019 ± 0.013  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.019 ± 0.013  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.019 ± 0.010  ops/ns
 
-SyncMapBenchmark.putOnly                    SyncMap         none  thrpt    5  0.239 ± 0.025  ops/ns
-SyncMapBenchmark.putOnly                    SyncMap      presize  thrpt    5  0.235 ± 0.044  ops/ns
-SyncMapBenchmark.putOnly                    SyncMap  prepopulate  thrpt    5  0.457 ± 0.026  ops/ns
+SyncMapBenchmark.put_only            SyncMap         none    false                50  100000  thrpt    5  0.222 ± 0.027  ops/ns
+SyncMapBenchmark.put_only            SyncMap         none     true                50  100000  thrpt    5  0.235 ± 0.041  ops/ns
+SyncMapBenchmark.put_only            SyncMap      presize    false                50  100000  thrpt    5  0.238 ± 0.012  ops/ns
+SyncMapBenchmark.put_only            SyncMap      presize     true                50  100000  thrpt    5  0.230 ± 0.019  ops/ns
+SyncMapBenchmark.put_only            SyncMap  prepopulate    false                50  100000  thrpt    5  0.232 ± 0.052  ops/ns
+SyncMapBenchmark.put_only            SyncMap  prepopulate     true                50  100000  thrpt    5  0.412 ± 0.048  ops/ns
 
-SyncMapBenchmark.putOnly          ConcurrentHashMap         none  thrpt    5  0.165 ± 0.008  ops/ns
-SyncMapBenchmark.putOnly          ConcurrentHashMap      presize  thrpt    5  0.336 ± 0.010  ops/ns
-SyncMapBenchmark.putOnly          ConcurrentHashMap  prepopulate  thrpt    5  0.297 ± 0.043  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  0.237 ± 0.257  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  0.202 ± 0.171  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.300 ± 0.029  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.286 ± 0.040  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.309 ± 0.044  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.299 ± 0.029  ops/ns
 
-SyncMapBenchmark.putOnly            SynchronizedMap         none  thrpt    5  0.023 ± 0.004  ops/ns
-SyncMapBenchmark.putOnly            SynchronizedMap      presize  thrpt    5  0.023 ± 0.005  ops/ns
-SyncMapBenchmark.putOnly            SynchronizedMap  prepopulate  thrpt    5  0.022 ± 0.003  ops/ns
-
-SyncMapBenchmark.randomPutAndGet            SyncMap         none  thrpt    5  0.192 ± 0.009  ops/ns
-SyncMapBenchmark.randomPutAndGet            SyncMap      presize  thrpt    5  0.203 ± 0.007  ops/ns
-SyncMapBenchmark.randomPutAndGet            SyncMap  prepopulate  thrpt    5  0.200 ± 0.002  ops/ns
-
-SyncMapBenchmark.randomPutAndGet  ConcurrentHashMap         none  thrpt    5  0.138 ± 0.002  ops/ns
-SyncMapBenchmark.randomPutAndGet  ConcurrentHashMap      presize  thrpt    5  0.147 ± 0.001  ops/ns
-SyncMapBenchmark.randomPutAndGet  ConcurrentHashMap  prepopulate  thrpt    5  0.146 ± 0.003  ops/ns
-
-SyncMapBenchmark.randomPutAndGet    SynchronizedMap         none  thrpt    5  0.017 ± 0.009  ops/ns
-SyncMapBenchmark.randomPutAndGet    SynchronizedMap      presize  thrpt    5  0.016 ± 0.013  ops/ns
-SyncMapBenchmark.randomPutAndGet    SynchronizedMap  prepopulate  thrpt    5  0.018 ± 0.004  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.024 ± 0.026  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.029 ± 0.042  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.021 ± 0.006  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.021 ± 0.005  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.026 ± 0.032  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.027 ± 0.032  ops/ns
 ```

--- a/collections/src/jmh/java/space/vectrix/sync/collections/SyncMapBenchmark.java
+++ b/collections/src/jmh/java/space/vectrix/sync/collections/SyncMapBenchmark.java
@@ -26,7 +26,7 @@ package space.vectrix.sync.collections;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -35,7 +35,6 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
@@ -45,89 +44,112 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-@BenchmarkMode(Mode.Throughput)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
 @Fork(1)
 @Warmup(iterations = 5)
 @Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class SyncMapBenchmark {
-  private static final int SIZE = 100_000;
+  @State(Scope.Benchmark)
+  public static class Container {
+    @Param({ "SyncMap", "ConcurrentHashMap", "SynchronizedMap" })
+    private String implementation;
 
-  @Param({ "SyncMap", "SynchronizedMap", "ConcurrentHashMap" })
-  private String implementation;
+    @Param({ "none", "presize", "prepopulate" })
+    private String mode;
 
-  @Param({ "none", "presize", "prepopulate" })
-  private String mode;
+    @Param({ "false", "true" })
+    private boolean prime;
 
-  private Map<Integer, Integer> map;
+    @Param({ "100000" })
+    private int size;
 
-  @Setup(Level.Iteration)
-  public void setup() {
-    final boolean presized = !"none".equalsIgnoreCase(this.mode);
-    final boolean prepopulate = "prepopulate".equalsIgnoreCase(this.mode);
+    private Map<Integer, Integer> map;
 
-    if ("SyncMap".equalsIgnoreCase(this.implementation)) {
-      this.map = presized ? new SyncMap<>(SyncMapBenchmark.SIZE) : new SyncMap<>();
-    } else if ("SynchronizedMap".equalsIgnoreCase(this.implementation)) {
-      this.map = presized
-        ? Collections.synchronizedMap(new HashMap<>(SyncMapBenchmark.SIZE))
-        : Collections.synchronizedMap(new HashMap<>());
-    } else if ("ConcurrentHashMap".equalsIgnoreCase(this.implementation)) {
-      this.map = presized ? new ConcurrentHashMap<>(SyncMapBenchmark.SIZE) : new ConcurrentHashMap<>();
-    }
+    @Setup(Level.Iteration)
+    public void setup() {
+      final boolean presized = !"none".equalsIgnoreCase(this.mode);
+      final boolean prepopulate = "prepopulate".equalsIgnoreCase(this.mode);
 
-    if(prepopulate) {
-      for(int i = 0; i < SyncMapBenchmark.SIZE; i++) {
-        this.map.put(i, i);
+      switch(this.implementation) {
+        case "SyncMap" -> this.map = presized ? new SyncMap<>(this.size) : new SyncMap<>();
+        case "ConcurrentHashMap" -> this.map = presized ? new ConcurrentHashMap<>(this.size) : new ConcurrentHashMap<>();
+        case "SynchronizedMap" -> this.map = presized
+          ? Collections.synchronizedMap(new HashMap<>(this.size))
+          : Collections.synchronizedMap(new HashMap<>());
+        default -> throw new IllegalArgumentException("Unable to identify implementation: " + this.implementation);
+      }
+
+      if(prepopulate) {
+        for(int i = 0; i < this.size; i++) {
+          this.map.put(i, i);
+        }
+      }
+
+      if(this.prime) {
+        if(this.map instanceof final SyncMap<Integer, Integer> syncMap) {
+          syncMap.promote();
+        } else {
+          for(int i = 0; i < this.size; i++) {
+            this.map.get(i);
+          }
+        }
       }
     }
-
-    if(presized && (this.map instanceof final SyncMap<Integer, Integer> sync)) {
-      sync.promote();
-    }
   }
 
-  @Benchmark
-  @Threads(8)
-  @OperationsPerInvocation(SyncMapBenchmark.SIZE)
-  public void getOnly(final Blackhole blackhole) {
-    for(int i = 0; i < SyncMapBenchmark.SIZE; i++) {
-      blackhole.consume(this.map.get(i));
-    }
-  }
+  @State(Scope.Thread)
+  public static class Sample {
+    @Param({ "50" })
+    private int readPercentage;
 
-  @Benchmark
-  @Threads(8)
-  @OperationsPerInvocation(SyncMapBenchmark.SIZE)
-  public void putOnly(final Blackhole blackhole) {
-    for(int i = 0; i < SyncMapBenchmark.SIZE; i++) {
-      blackhole.consume(this.map.put(i, i));
-    }
-  }
+    private int cursor;
+    private int length;
+    private boolean[] isRead;
 
-  @Benchmark
-  @Threads(8)
-  @OperationsPerInvocation(SyncMapBenchmark.SIZE)
-  public void putAndGet(final Blackhole blackhole) {
-    for(int i = 0; i < SyncMapBenchmark.SIZE; i++) {
-      blackhole.consume(this.map.put(i, i));
-      blackhole.consume(this.map.get(i));
-    }
-  }
+    @Setup(Level.Iteration)
+    public void setup(final Container container) {
+      this.length = container.size;
+      this.isRead = new boolean[this.length];
 
-  @Benchmark
-  @Threads(8)
-  @OperationsPerInvocation(SyncMapBenchmark.SIZE)
-  public void randomPutAndGet(final Blackhole blackhole) {
-    final Random random = new Random(8);
-    for(int i = 0; i < SyncMapBenchmark.SIZE; i++) {
-      final int key = random.nextInt(SyncMapBenchmark.SIZE);
-      if(random.nextBoolean()) {
-        blackhole.consume(this.map.put(key, key));
-      } else {
-        blackhole.consume(this.map.get(key));
+      final SplittableRandom random = new SplittableRandom(Thread.currentThread().getId());
+      for(int i = 0; i < this.length; i++) {
+        this.isRead[i] = random.nextInt(100) < this.readPercentage;
       }
+
+      this.cursor = 0;
+    }
+
+    private int next() {
+      final int i = this.cursor;
+      this.cursor = (i + 1) % this.length;
+      return i;
+    }
+  }
+
+  @Benchmark
+  @Threads(8)
+  public void get_only(final Container container, final Sample sample, final Blackhole blackhole) {
+    final int key = sample.next();
+    blackhole.consume(container.map.get(key));
+  }
+
+  @Benchmark
+  @Threads(8)
+  public void put_only(final Container container, final Sample sample, final Blackhole blackhole) {
+    final int key = sample.next();
+    blackhole.consume(container.map.put(key, key));
+  }
+
+  @Benchmark
+  @Threads(8)
+  public void get_put(final Container container, final Sample sample, final Blackhole blackhole) {
+    final int key = sample.next();
+
+    if(sample.isRead[key]) {
+      blackhole.consume(container.map.get(key));
+    } else {
+      blackhole.consume(container.map.put(key, key));
     }
   }
 }

--- a/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
+++ b/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
@@ -254,6 +254,12 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
   private transient volatile boolean amended;
 
   /**
+   * Represents the capacity of the mutable table and initially the length to
+   * initialize the table at.
+   */
+  private transient volatile int capacity;
+
+  /**
    * Represents the transfer index a thread may claim a range of when
    * participating in a transfer operation.
    */
@@ -324,7 +330,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       : SyncMap.tableSizeFor(initialCapacity);
 
     this.loadFactor = loadFactor;
-    this.immutableTable = (Node<K, V>[]) new Node[capacity];
+    this.capacity = capacity;
+
+    this.immutableTable = new Node[0];
   }
 
   @Override
@@ -344,99 +352,175 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
   public boolean containsKey(final @NotNull Object key) {
     requireNonNull(key, "key");
 
-    final int hash = SyncMap.spread(key.hashCode());
-
-    final ObjectReference reference = this.getValue(hash, key);
-    if(reference == null) return false;
-
-    final Object value = reference.get();
-    return value != null && value != SyncMap.EXPUNGED;
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public @Nullable V get(final @NotNull Object key) {
-    requireNonNull(key, "key");
+    Node<K, V>[] table = this.immutableTable; int length = table.length;
+    Node<K, V> node, nextNode;
+    int nodeHash; K nodeKey;
 
     final int hash = SyncMap.spread(key.hashCode());
 
-    final ObjectReference reference = this.getValue(hash, key);
-    if(reference == null) return null;
-
-    final Object value = reference.get();
-    if(value == SyncMap.EXPUNGED) return null;
-
-    return (V) value;
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public @NotNull V getOrDefault(final @NotNull Object key, final @NotNull V defaultValue) {
-    requireNonNull(key, "key");
-    requireNonNull(defaultValue, "defaultValue");
-
-    final int hash = SyncMap.spread(key.hashCode());
-
-    final ObjectReference reference = this.getValue(hash, key);
-    if(reference == null) return defaultValue;
-
-    final Object value = reference.get();
-    if(value == null || value == SyncMap.EXPUNGED) return defaultValue;
-
-    return (V) value;
-  }
-
-  /* package */ final @Nullable ObjectReference getValue(final int hash, final @NotNull Object key) {
-    ObjectReference reference;
-    if((reference = this.getImmutableValue(hash, key)) != null) {
-      return reference;
-    } else if(this.amended) {
-      reference = this.getMutableValue(hash, key);
-
-      this.miss();
-      return reference;
-    }
-
-    return null;
-  }
-
-  /* package */ final @Nullable ObjectReference getImmutableValue(final int hash, final @NotNull Object key) {
-    final Node<K, V>[] table = this.immutableTable;
-
-    Node<K, V> node; K nodeKey;
-    if((node = SyncMap.getNode(table, (table.length - 1) & hash)) != null) {
-      do {
-        if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-          return node.reference;
-        }
-      } while((node = node.next) != null);
-    }
-
-    return null;
-  }
-
-  /* package */ final @Nullable ObjectReference getMutableValue(final int hash, final @NotNull Object key) {
-    final Node<K, V>[] table = this.mutableTable;
-    Node<K, V> node;
-    final int nodeHash; K nodeKey;
-
-    if(table != null && (node = SyncMap.getNode(table, (table.length - 1) & hash)) != null) {
+    if(length > 0 && (node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
       if((nodeHash = node.hash) == hash) {
         if((nodeKey = node.key) == key || nodeKey.equals(key)) {
-          return node.reference;
+          return node.reference().valueExists();
         }
       } else if(nodeHash < 0) {
-        return (node = node.find(hash, key)) != null ? node.reference : null;
+        if((nextNode = node.find(hash, key)) != null) {
+          return nextNode.reference().valueExists();
+        }
       }
 
       while((node = node.next) != null) {
         if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-          return node.reference;
+          return node.reference().valueExists();
         }
       }
     }
 
+    if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
+      boolean exists = false;
+      retry: if((node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
+        if((nodeHash = node.hash) == hash) {
+          if((nodeKey = node.key) == key || nodeKey.equals(key)) {
+            exists = node.reference().valueExists();
+            break retry;
+          }
+        } else if(nodeHash < 0) {
+          if((nextNode = node.find(hash, key)) != null) {
+            exists = nextNode.reference().valueExists();
+            break retry;
+          }
+        }
+
+        while((node = node.next) != null) {
+          if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
+            exists = node.reference().valueExists();
+            break retry;
+          }
+        }
+      }
+
+      this.miss();
+      return exists;
+    }
+
+    return false;
+  }
+
+  @Override
+  public @Nullable V get(final @NotNull Object key) {
+    requireNonNull(key, "key");
+
+    Node<K, V>[] table = this.immutableTable; int length = table.length;
+    Node<K, V> node, nextNode;
+    int nodeHash; K nodeKey;
+
+    final int hash = SyncMap.spread(key.hashCode());
+
+    if(length > 0 && (node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
+      if((nodeHash = node.hash) == hash) {
+        if((nodeKey = node.key) == key || nodeKey.equals(key)) {
+          return node.reference().value();
+        }
+      } else if(nodeHash < 0) {
+        if((nextNode = node.find(hash, key)) != null) {
+          return nextNode.reference().value();
+        }
+      }
+
+      while((node = node.next) != null) {
+        if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
+          return node.reference().value();
+        }
+      }
+    }
+
+    if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
+      V value = null;
+      retry: if((node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
+        if((nodeHash = node.hash) == hash) {
+          if((nodeKey = node.key) == key || nodeKey.equals(key)) {
+            value = node.reference().value();
+            break retry;
+          }
+        } else if(nodeHash < 0) {
+          if((nextNode = node.find(hash, key)) != null) {
+            value = nextNode.reference().value();
+            break retry;
+          }
+        }
+
+        while((node = node.next) != null) {
+          if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
+            value = node.reference().value();
+            break retry;
+          }
+        }
+      }
+
+      this.miss();
+      return value;
+    }
+
     return null;
+  }
+
+  @Override
+  public @NotNull V getOrDefault(final @NotNull Object key, final @NotNull V defaultValue) {
+    requireNonNull(key, "key");
+    requireNonNull(defaultValue, "defaultValue");
+
+    Node<K, V>[] table = this.immutableTable; int length = table.length;
+    Node<K, V> node, nextNode;
+    int nodeHash; K nodeKey;
+
+    final int hash = SyncMap.spread(key.hashCode());
+
+    if(length > 0 && (node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
+      if((nodeHash = node.hash) == hash) {
+        if((nodeKey = node.key) == key || nodeKey.equals(key)) {
+          return node.reference().valueOr(defaultValue);
+        }
+      } else if(nodeHash < 0) {
+        if((nextNode = node.find(hash, key)) != null) {
+          return nextNode.reference().valueOr(defaultValue);
+        }
+      }
+
+      while((node = node.next) != null) {
+        if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
+          return node.reference().valueOr(defaultValue);
+        }
+      }
+    }
+
+    if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
+      V value = defaultValue;
+      retry: if((node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
+        if((nodeHash = node.hash) == hash) {
+          if((nodeKey = node.key) == key || nodeKey.equals(key)) {
+            value = node.reference().valueOr(defaultValue);
+            break retry;
+          }
+        } else if(nodeHash < 0) {
+          if((nextNode = node.find(hash, key)) != null) {
+            value = nextNode.reference().valueOr(defaultValue);
+            break retry;
+          }
+        }
+
+        while((node = node.next) != null) {
+          if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
+            value = node.reference().valueOr(defaultValue);
+            break retry;
+          }
+        }
+      }
+
+      this.miss();
+      return value;
+    }
+
+    return defaultValue;
   }
 
   @Override
@@ -445,62 +529,72 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(key, "key");
     requireNonNull(mappingFunction, "mappingFunction");
 
+    Node<K, V>[] immutable, mutable = null; int length;
+    Node<K, V> node; K nodeKey;
+
     final int hash = SyncMap.spread(key.hashCode());
 
     V next;
-    retry: for(Node<K, V>[] immutableTable, mutableTable = null; ; ) {
-      Node<K, V> node = SyncMap.getNode((immutableTable = this.immutableTable), immutableTable.length - 1 & hash);
-      while(node != null) {
-        final K nodeKey;
-        if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-          node = node.next;
-          continue;
-        }
-
-        final ObjectReference reference = node.reference;
-        Object previous = reference.get();
-        for(; ; ) {
-          if(previous != null && previous != SyncMap.EXPUNGED) return (V) previous;
-
-          next = mappingFunction.apply(key);
-          if(next == null) return null;
-
-          final Object witness = reference.compareAndExchange(previous, next);
-          if(witness != previous) {
-            previous = witness;
-            Thread.onSpinWait();
+    retry: for(; ; ) {
+      immutable = this.immutableTable; length = immutable.length;
+      if(length > 0) {
+        // Find the node from the immutable table and update the value if the
+        // node is present and the value is null or expunged.
+        node = SyncMap.getNode(immutable, (length - 1) & hash);
+        while(node != null) {
+          if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
+            node = node.next;
             continue;
           }
 
-          if(witness == SyncMap.EXPUNGED) {
-            this.amendNode(hash, key, reference);
-          }
+          final ObjectReference reference = node.reference();
+          Object previous = reference.get();
+          for(; ; ) {
+            if(previous != null && previous != SyncMap.EXPUNGED) return (V) previous;
 
-          break retry;
+            next = mappingFunction.apply(key);
+            if(next == null) return null;
+
+            final Object witness = reference.compareAndExchange(previous, next);
+            if(witness != previous) {
+              previous = witness;
+              Thread.onSpinWait();
+              continue;
+            }
+
+            if(witness == SyncMap.EXPUNGED) {
+              this.amendNode(hash, key, reference);
+            }
+
+            break retry;
+          }
         }
       }
 
-      final int length, index;
-      if(!this.amended || (mutableTable == null && (mutableTable = this.mutableTable) == null) || (length = mutableTable.length) == 0) {
-        this.amend();
-      } else if((node = SyncMap.getNode(mutableTable, index = (length - 1) & hash)) == null) {
+      final int index;
+      if(!this.amended || (mutable == null && (mutable = this.mutableTable) == null)) {
+        if(length != 0 || (mutable = this.initialize()) != null) {
+          this.amend();
+        }
+
+        Thread.onSpinWait();
+      } else if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) == null) {
         next = mappingFunction.apply(key);
         if(next == null) return null;
 
-        if(SyncMap.replaceNode(mutableTable, index, new Node<>(hash, key, new ObjectReference(next)))) {
+        if(SyncMap.replaceNode(mutable, index, new Node<>(hash, key, new ObjectReference(next)))) {
           break;
         }
 
         Thread.onSpinWait();
       } else if(node.hash == SyncMap.NODE_MOVED) {
-        mutableTable = this.forward((ForwardingNode<K, V>) node);
+        mutable = this.forward((ForwardingNode<K, V>) node);
       } else {
         synchronized(node) {
-          if(SyncMap.getNode(mutableTable, index) == node) {
+          if(SyncMap.getNode(mutable, index) == node) {
             for(; ; ) {
-              final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference;
+                final ObjectReference reference = node.reference();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous != null && previous != SyncMap.EXPUNGED) return (V) previous;
@@ -543,49 +637,55 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(key, "key");
     requireNonNull(remappingFunction, "remappingFunction");
 
+    Node<K, V>[] immutable, mutable; int length;
+    Node<K, V> node; K nodeKey;
+
     final int hash = SyncMap.spread(key.hashCode());
 
     V next; long count = 0L;
-    retry: for(Node<K, V>[] table; ; ) {
-      Node<K, V> node = SyncMap.getNode((table = this.immutableTable), table.length - 1 & hash);
-      while(node != null) {
-        final K nodeKey;
-        if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-          node = node.next;
-          continue;
-        }
-
-        final ObjectReference reference = node.reference;
-        Object previous = reference.get();
-        for(; ; ) {
-          if(previous == null || previous == SyncMap.EXPUNGED) return null;
-          next = remappingFunction.apply(key, (V) previous);
-
-          final Object witness = reference.compareAndExchange(previous, next);
-          if(witness != previous) {
-            previous = witness;
-            Thread.onSpinWait();
+    retry: for(; ; ) {
+      immutable = this.immutableTable; length = immutable.length;
+      if(length > 0) {
+        // Find the node from the immutable table and update the value if the
+        // node is present.
+        node = SyncMap.getNode(immutable, (length - 1) & hash);
+        while(node != null) {
+          if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
+            node = node.next;
             continue;
           }
 
-          if(next == null) {
-            count = -1L;
-          }
+          final ObjectReference reference = node.reference();
+          Object previous = reference.get();
+          for(; ; ) {
+            if(previous == null || previous == SyncMap.EXPUNGED) return null;
+            next = remappingFunction.apply(key, (V) previous);
 
-          break retry;
+            final Object witness = reference.compareAndExchange(previous, next);
+            if(witness != previous) {
+              previous = witness;
+              Thread.onSpinWait();
+              continue;
+            }
+
+            if(next == null) {
+              count = -1L;
+            }
+
+            break retry;
+          }
         }
       }
 
-      if(!this.amended || (table = this.mutableTable) == null) return null;
+      if(!this.amended || (mutable = this.mutableTable) == null) return null;
 
       final int index;
-      if((node = SyncMap.getNode(table, index = (table.length - 1) & hash)) != null) {
+      if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if(SyncMap.getNode(table, index) == node) {
+          if(SyncMap.getNode(mutable, index) == node) {
             for(Node<K, V> previousNode = null; ; ) {
-              final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference;
+                final ObjectReference reference = node.reference();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous == null || previous == SyncMap.EXPUNGED) return null;
@@ -602,7 +702,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                     if(previousNode != null) {
                       previousNode.next = node.next;
                     } else {
-                      SyncMap.setNode(table, index, node.next);
+                      SyncMap.setNode(mutable, index, node.next);
                     }
 
                     count = -1L;
@@ -633,69 +733,79 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(key, "key");
     requireNonNull(remappingFunction, "remappingFunction");
 
+    Node<K, V>[] immutable, mutable = null; int length;
+    Node<K, V> node; K nodeKey;
+
     final int hash = SyncMap.spread(key.hashCode());
 
     V next; long count = 0L;
-    retry: for(Node<K, V>[] immutableTable, mutableTable = null; ; ) {
-      Node<K, V> node = SyncMap.getNode((immutableTable = this.immutableTable), immutableTable.length - 1 & hash);
-      while(node != null) {
-        final K nodeKey;
-        if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-          node = node.next;
-          continue;
-        }
-
-        final ObjectReference reference = node.reference;
-        Object previous = reference.get();
-        for(; ; ) {
-          next = remappingFunction.apply(key, previous == SyncMap.EXPUNGED ? null : (V) previous);
-          if(next == null && (previous == null || previous == SyncMap.EXPUNGED)) return null;
-
-          final Object witness = reference.compareAndExchange(previous, next);
-          if(witness != previous) {
-            previous = witness;
-            Thread.onSpinWait();
+    retry: for(; ; ) {
+      immutable = this.immutableTable; length = immutable.length;
+      if(length > 0) {
+        // Find the node from the immutable table and update the value if the
+        // node is present.
+        node = SyncMap.getNode(immutable, (length - 1) & hash);
+        while(node != null) {
+          if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
+            node = node.next;
             continue;
           }
 
-          if(next != null) {
-            if(witness == null) {
-              count = 1L;
-            } else if(witness == SyncMap.EXPUNGED) {
-              this.amendNode(hash, key, reference);
+          final ObjectReference reference = node.reference();
+          Object previous = reference.get();
+          for(; ; ) {
+            next = remappingFunction.apply(key, previous == SyncMap.EXPUNGED ? null : (V) previous);
+            if(next == null && (previous == null || previous == SyncMap.EXPUNGED)) return null;
 
-              count = 1L;
+            final Object witness = reference.compareAndExchange(previous, next);
+            if(witness != previous) {
+              previous = witness;
+              Thread.onSpinWait();
+              continue;
             }
-          } else {
-            count = -1L;
-          }
 
-          break retry;
+            if(next != null) {
+              if(witness == null) {
+                count = 1L;
+              } else if(witness == SyncMap.EXPUNGED) {
+                this.amendNode(hash, key, reference);
+
+                count = 1L;
+              }
+            } else {
+              count = -1L;
+            }
+
+            break retry;
+          }
         }
       }
 
-      final int length, index;
-      if(!this.amended || (mutableTable == null && (mutableTable = this.mutableTable) == null) || (length = mutableTable.length) == 0) {
-        this.amend();
-      } else if((node = SyncMap.getNode(mutableTable, index = (length - 1) & hash)) == null) {
+      final int index;
+      if(!this.amended || (mutable == null && (mutable = this.mutableTable) == null)) {
+        if(length != 0 || (mutable = this.initialize()) != null) {
+          this.amend();
+        }
+
+        Thread.onSpinWait();
+      } else if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) == null) {
         next = remappingFunction.apply(key, null);
         if(next == null) return null;
 
-        if(SyncMap.replaceNode(mutableTable, index, new Node<>(hash, key, new ObjectReference(next)))) {
+        if(SyncMap.replaceNode(mutable, index, new Node<>(hash, key, new ObjectReference(next)))) {
           count = 1L;
           break;
         }
 
         Thread.onSpinWait();
       } else if(node.hash == SyncMap.NODE_MOVED) {
-        mutableTable = this.forward((ForwardingNode<K, V>) node);
+        mutable = this.forward((ForwardingNode<K, V>) node);
       } else {
         synchronized(node) {
-          if(SyncMap.getNode(mutableTable, index) == node) {
+          if(SyncMap.getNode(mutable, index) == node) {
             for(Node<K, V> previousNode = null; ; ) {
-              final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference;
+                final ObjectReference reference = node.reference();
                 Object previous = reference.get();
                 for(; ; ) {
                   next = remappingFunction.apply(key, previous == SyncMap.EXPUNGED ? null : (V) previous);
@@ -714,7 +824,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                     if(previousNode != null) {
                       previousNode.next = node.next;
                     } else {
-                      SyncMap.setNode(mutableTable, index, node.next);
+                      SyncMap.setNode(mutable, index, node.next);
                     }
 
                     count = -1L;
@@ -751,55 +861,65 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(key, "key");
     requireNonNull(value, "value");
 
+    Node<K, V>[] immutable, mutable = null; int length;
+    Node<K, V> node; K nodeKey;
+
     final int hash = SyncMap.spread(key.hashCode());
 
-    retry: for(Node<K, V>[] immutableTable, mutableTable = null; ; ) {
-      Node<K, V> node = SyncMap.getNode((immutableTable = this.immutableTable), immutableTable.length - 1 & hash);
-      while(node != null) {
-        final K nodeKey;
-        if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-          node = node.next;
-          continue;
-        }
-
-        final ObjectReference reference = node.reference;
-        Object previous = reference.get();
-        for(; ; ) {
-          if(previous != null && previous != SyncMap.EXPUNGED) return (V) previous;
-
-          final Object witness = reference.compareAndExchange(previous, value);
-          if(witness != previous) {
-            previous = witness;
-            Thread.onSpinWait();
+    retry: for(; ; ) {
+      immutable = this.immutableTable; length = immutable.length;
+      if(length > 0) {
+        // Find the node from the immutable table and update the value if the
+        // node is present and the value is null or expunged.
+        node = SyncMap.getNode(immutable, (length - 1) & hash);
+        while(node != null) {
+          if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
+            node = node.next;
             continue;
           }
 
-          if(witness == SyncMap.EXPUNGED) {
-            this.amendNode(hash, key, reference);
-          }
+          final ObjectReference reference = node.reference();
+          Object previous = reference.get();
+          for(; ; ) {
+            if(previous != null && previous != SyncMap.EXPUNGED) return (V) previous;
 
-          break retry;
+            final Object witness = reference.compareAndExchange(previous, value);
+            if(witness != previous) {
+              previous = witness;
+              Thread.onSpinWait();
+              continue;
+            }
+
+            if(witness == SyncMap.EXPUNGED) {
+              this.amendNode(hash, key, reference);
+            }
+
+            break retry;
+          }
         }
       }
 
-      final int length, index;
-      if(!this.amended || (mutableTable == null && (mutableTable = this.mutableTable) == null) || (length = mutableTable.length) == 0) {
-        this.amend();
-      } else if((node = SyncMap.getNode(mutableTable, index = (length - 1) & hash)) == null) {
-        if(SyncMap.replaceNode(mutableTable, index, new Node<>(hash, key, new ObjectReference(value)))) {
+      final int index;
+      if(!this.amended || (mutable == null && (mutable = this.mutableTable) == null)) {
+        if(length != 0 || (mutable = this.initialize()) != null) {
+          this.amend();
+        }
+
+        Thread.onSpinWait();
+      } else if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) == null) {
+        if(SyncMap.replaceNode(mutable, index, new Node<>(hash, key, new ObjectReference(value)))) {
           break;
         }
 
         Thread.onSpinWait();
       } else if(node.hash == SyncMap.NODE_MOVED) {
-        mutableTable = this.forward((ForwardingNode<K, V>) node);
+        mutable = this.forward((ForwardingNode<K, V>) node);
       } else {
         synchronized(node) {
-          if(SyncMap.getNode(mutableTable, index) == node) {
+          if(SyncMap.getNode(mutable, index) == node) {
             for(; ; ) {
-              final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference;
+                final ObjectReference reference = node.reference();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous != null && previous != SyncMap.EXPUNGED) return (V) previous;
@@ -836,55 +956,65 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(key, "key");
     requireNonNull(value, "value");
 
+    Node<K, V>[] immutable, mutable = null; int length;
+    Node<K, V> node; K nodeKey;
+
     final int hash = SyncMap.spread(key.hashCode());
 
-    retry: for(Node<K, V>[] immutableTable, mutableTable = null; ; ) {
-      Node<K, V> node = SyncMap.getNode((immutableTable = this.immutableTable), immutableTable.length - 1 & hash);
-      while(node != null) {
-        final K nodeKey;
-        if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-          node = node.next;
-          continue;
-        }
-
-        final ObjectReference reference = node.reference;
-        Object previous = reference.get();
-        for(; ; ) {
-          final Object witness = reference.compareAndExchange(previous, value);
-          if(witness != previous) {
-            previous = witness;
-            Thread.onSpinWait();
+    retry: for(; ; ) {
+      immutable = this.immutableTable; length = immutable.length;
+      if(length > 0) {
+        // Find the node from the immutable table and update the value if the
+        // node is present.
+        node = SyncMap.getNode(immutable, (length - 1) & hash);
+        while(node != null) {
+          if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
+            node = node.next;
             continue;
           }
 
-          if(witness == SyncMap.EXPUNGED) {
-            this.amendNode(hash, key, reference);
-          } else if(witness != null) {
-            return (V) witness;
-          }
+          final ObjectReference reference = node.reference();
+          Object previous = reference.get();
+          for(; ; ) {
+            final Object witness = reference.compareAndExchange(previous, value);
+            if(witness != previous) {
+              previous = witness;
+              Thread.onSpinWait();
+              continue;
+            }
 
-          break retry;
+            if(witness == SyncMap.EXPUNGED) {
+              this.amendNode(hash, key, reference);
+            } else if(witness != null) {
+              return (V) witness;
+            }
+
+            break retry;
+          }
         }
       }
 
-      final int length, index;
-      if(!this.amended || (mutableTable == null && (mutableTable = this.mutableTable) == null) || (length = mutableTable.length) == 0) {
-        this.amend();
-      } else if((node = SyncMap.getNode(mutableTable, index = (length - 1) & hash)) == null) {
-        if(SyncMap.replaceNode(mutableTable, index, new Node<>(hash, key, new ObjectReference(value)))) {
+      final int index;
+      if(!this.amended || (mutable == null && (mutable = this.mutableTable) == null)) {
+        if(length != 0 || (mutable = this.initialize()) != null) {
+          this.amend();
+        }
+
+        Thread.onSpinWait();
+      } else if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) == null) {
+        if(SyncMap.replaceNode(mutable, index, new Node<>(hash, key, new ObjectReference(value)))) {
           break;
         }
 
         Thread.onSpinWait();
       } else if(node.hash == SyncMap.NODE_MOVED) {
-        mutableTable = this.forward((ForwardingNode<K, V>) node);
+        mutable = this.forward((ForwardingNode<K, V>) node);
       } else {
         synchronized(node) {
-          if(SyncMap.getNode(mutableTable, index) == node) {
+          if(SyncMap.getNode(mutable, index) == node) {
             for(; ; ) {
-              final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference;
+                final ObjectReference reference = node.reference();
                 Object previous = reference.get();
                 for(; ; ) {
                   final Object witness = reference.compareAndExchange(previous, value);
@@ -938,7 +1068,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
             for(; ; ) {
               final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                node.reference = reference;
+                node.reference(reference);
                 return;
               }
 
@@ -959,44 +1089,50 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
   public @Nullable V remove(final @NotNull Object key) {
     requireNonNull(key, "key");
 
+    Node<K, V>[] immutable, mutable; int length;
+    Node<K, V> node; K nodeKey;
+
     final int hash = SyncMap.spread(key.hashCode());
 
     Object previous;
-    retry: for(Node<K, V>[] table; ; ) {
-      Node<K, V> node = SyncMap.getNode((table = this.immutableTable), table.length - 1 & hash);
-      while(node != null) {
-        final K nodeKey;
-        if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-          node = node.next;
-          continue;
-        }
-
-        final ObjectReference reference = node.reference;
-        Object current = reference.get();
-        for(; ; ) {
-          if(current == null || current == SyncMap.EXPUNGED) return null;
-
-          previous = reference.compareAndExchange(current, null);
-          if(previous != current) {
-            current = previous;
-            Thread.onSpinWait();
+    retry: for(; ; ) {
+      immutable = this.immutableTable; length = immutable.length;
+      if(length > 0) {
+        // Find the node from the immutable table and update the value if the
+        // node is present.
+        node = SyncMap.getNode(immutable, (length - 1) & hash);
+        while(node != null) {
+          if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
+            node = node.next;
             continue;
           }
 
-          break retry;
+          final ObjectReference reference = node.reference();
+          Object current = reference.get();
+          for(; ; ) {
+            if(current == null || current == SyncMap.EXPUNGED) return null;
+
+            previous = reference.compareAndExchange(current, null);
+            if(previous != current) {
+              current = previous;
+              Thread.onSpinWait();
+              continue;
+            }
+
+            break retry;
+          }
         }
       }
 
-      if(!this.amended || (table = this.mutableTable) == null) return null;
+      if(!this.amended || (mutable = this.mutableTable) == null) return null;
 
       final int index;
-      if((node = SyncMap.getNode(table, index = (table.length - 1) & hash)) != null) {
+      if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if(SyncMap.getNode(table, index) == node) {
+          if(SyncMap.getNode(mutable, index) == node) {
             for(Node<K, V> previousNode = null; ; ) {
-              final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference;
+                final ObjectReference reference = node.reference();
                 Object current = reference.get();
                 for(; ; ) {
                   if(current == null || current == SyncMap.EXPUNGED) return null;
@@ -1011,7 +1147,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                   if(previousNode != null) {
                     previousNode.next = node.next;
                   } else {
-                    SyncMap.setNode(table, index, node.next);
+                    SyncMap.setNode(mutable, index, node.next);
                   }
 
                   break retry;
@@ -1038,44 +1174,50 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(key, "key");
     requireNonNull(value, "value");
 
+    Node<K, V>[] immutable, mutable; int length;
+    Node<K, V> node; K nodeKey;
+
     final int hash = SyncMap.spread(key.hashCode());
 
-    retry: for(Node<K, V>[] table; ; ) {
-      Node<K, V> node = SyncMap.getNode((table = this.immutableTable), table.length - 1 & hash);
-      while(node != null) {
-        final K nodeKey;
-        if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-          node = node.next;
-          continue;
-        }
-
-        final ObjectReference reference = node.reference;
-        Object previous = reference.get();
-        for(; ; ) {
-          if(previous == null || previous == SyncMap.EXPUNGED) return false;
-          if(!Objects.equals(value, previous)) return false;
-
-          final Object witness = reference.compareAndExchange(previous, null);
-          if(witness != previous) {
-            previous = witness;
-            Thread.onSpinWait();
+    retry: for(; ; ) {
+      immutable = this.immutableTable; length = immutable.length;
+      if(length > 0) {
+        // Find the node from the immutable table and update the value if the
+        // node is present.
+        node = SyncMap.getNode(immutable, (length - 1) & hash);
+        while(node != null) {
+          if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
+            node = node.next;
             continue;
           }
 
-          break retry;
+          final ObjectReference reference = node.reference();
+          Object previous = reference.get();
+          for(; ; ) {
+            if(previous == null || previous == SyncMap.EXPUNGED) return false;
+            if(!Objects.equals(value, previous)) return false;
+
+            final Object witness = reference.compareAndExchange(previous, null);
+            if(witness != previous) {
+              previous = witness;
+              Thread.onSpinWait();
+              continue;
+            }
+
+            break retry;
+          }
         }
       }
 
-      if(!this.amended || (table = this.mutableTable) == null) return false;
+      if(!this.amended || (mutable = this.mutableTable) == null) return false;
 
       final int index;
-      if((node = SyncMap.getNode(table, index = (table.length - 1) & hash)) != null) {
+      if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if(SyncMap.getNode(table, index) == node) {
+          if(SyncMap.getNode(mutable, index) == node) {
             for(Node<K, V> previousNode = null; ; ) {
-              final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference;
+                final ObjectReference reference = node.reference();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous == null || previous == SyncMap.EXPUNGED) return false;
@@ -1091,7 +1233,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                   if(previousNode != null) {
                     previousNode.next = node.next;
                   } else {
-                    SyncMap.setNode(table, index, node.next);
+                    SyncMap.setNode(mutable, index, node.next);
                   }
 
                   break retry;
@@ -1119,44 +1261,50 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(key, "key");
     requireNonNull(value, "value");
 
+    Node<K, V>[] immutable, mutable; int length;
+    Node<K, V> node; K nodeKey;
+
     final int hash = SyncMap.spread(key.hashCode());
 
     Object previous;
-    retry: for(Node<K, V>[] table; ; ) {
-      Node<K, V> node = SyncMap.getNode((table = this.immutableTable), table.length - 1 & hash);
-      while(node != null) {
-        final K nodeKey;
-        if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-          node = node.next;
-          continue;
-        }
-
-        final ObjectReference reference = node.reference;
-        Object current = reference.get();
-        for(; ; ) {
-          if(current == null || current == SyncMap.EXPUNGED) return null;
-
-          previous = reference.compareAndExchange(current, value);
-          if(previous != current) {
-            current = previous;
-            Thread.onSpinWait();
+    retry: for(; ; ) {
+      immutable = this.immutableTable; length = immutable.length;
+      if(length > 0) {
+        // Find the node from the immutable table and update the value if the
+        // node is present.
+        node = SyncMap.getNode(immutable, (length - 1) & hash);
+        while(node != null) {
+          if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
+            node = node.next;
             continue;
           }
 
-          break retry;
+          final ObjectReference reference = node.reference();
+          Object current = reference.get();
+          for(; ; ) {
+            if(current == null || current == SyncMap.EXPUNGED) return null;
+
+            previous = reference.compareAndExchange(current, value);
+            if(previous != current) {
+              current = previous;
+              Thread.onSpinWait();
+              continue;
+            }
+
+            break retry;
+          }
         }
       }
 
-      if(!this.amended || (table = this.mutableTable) == null) return null;
+      if(!this.amended || (mutable = this.mutableTable) == null) return null;
 
       final int index;
-      if((node = SyncMap.getNode(table, index = (table.length - 1) & hash)) != null) {
+      if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if(SyncMap.getNode(table, index) == node) {
+          if(SyncMap.getNode(mutable, index) == node) {
             for(; ; ) {
-              final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference;
+                final ObjectReference reference = node.reference();
                 Object current = reference.get();
                 for(; ; ) {
                   if(current == null || current == SyncMap.EXPUNGED) return null;
@@ -1190,45 +1338,51 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(oldValue, "oldValue");
     requireNonNull(newValue, "newValue");
 
+    Node<K, V>[] immutable, mutable; int length;
+    Node<K, V> node; K nodeKey;
+
     final int hash = SyncMap.spread(key.hashCode());
 
     Object previous;
-    retry: for(Node<K, V>[] table; ; ) {
-      Node<K, V> node = SyncMap.getNode((table = this.immutableTable), table.length - 1 & hash);
-      while(node != null) {
-        final K nodeKey;
-        if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-          node = node.next;
-          continue;
-        }
-
-        final ObjectReference reference = node.reference;
-        Object current = reference.get();
-        for(; ; ) {
-          if(current == null || current == SyncMap.EXPUNGED) return false;
-          if(!Objects.equals(current, oldValue)) return false;
-
-          previous = reference.compareAndExchange(current, newValue);
-          if(previous != current) {
-            current = previous;
-            Thread.onSpinWait();
+    retry: for(; ; ) {
+      immutable = this.immutableTable; length = immutable.length;
+      if(length > 0) {
+        // Find the node from the immutable table and update the value if the
+        // node is present.
+        node = SyncMap.getNode(immutable, (length - 1) & hash);
+        while(node != null) {
+          if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
+            node = node.next;
             continue;
           }
 
-          break retry;
+          final ObjectReference reference = node.reference();
+          Object current = reference.get();
+          for(; ; ) {
+            if(current == null || current == SyncMap.EXPUNGED) return false;
+            if(!Objects.equals(current, oldValue)) return false;
+
+            previous = reference.compareAndExchange(current, newValue);
+            if(previous != current) {
+              current = previous;
+              Thread.onSpinWait();
+              continue;
+            }
+
+            break retry;
+          }
         }
       }
 
-      if(!this.amended || (table = this.mutableTable) == null) return false;
+      if(!this.amended || (mutable = this.mutableTable) == null) return false;
 
       final int index;
-      if((node = SyncMap.getNode(table, index = (table.length - 1) & hash)) != null) {
+      if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if(SyncMap.getNode(table, index) == node) {
+          if(SyncMap.getNode(mutable, index) == node) {
             for(; ; ) {
-              final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference;
+                final ObjectReference reference = node.reference();
                 Object current = reference.get();
                 for(; ; ) {
                   if(current == null || current == SyncMap.EXPUNGED) return false;
@@ -1266,14 +1420,17 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
     this.promote();
 
-    final Traverser<K, V> traverser = new Traverser<>(this.immutableTable);
+    final Node<K, V>[] table = this.immutableTable;
+    if(table.length > 0) {
+      final Traverser<K, V> traverser = new Traverser<>(table);
 
-    Node<K, V> node;
-    while((node = traverser.advanceNode()) != null) {
-      final Object current = node.reference.get();
-      if(current == null || current == SyncMap.EXPUNGED) continue;
+      Node<K, V> node;
+      while((node = traverser.advanceNode()) != null) {
+        final Object current = node.reference().get();
+        if(current == null || current == SyncMap.EXPUNGED) continue;
 
-      action.accept(node.key, (V) current);
+        action.accept(node.key, (V) current);
+      }
     }
   }
 
@@ -1281,28 +1438,31 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
   public void clear() {
     this.promote();
 
-    final Traverser<K, V> traverser = new Traverser<>(this.immutableTable);
+    final Node<K, V>[] table = this.immutableTable;
+    if(table.length > 0) {
+      final Traverser<K, V> traverser = new Traverser<>(table);
 
-    Node<K, V> node; long count = 0L;
-    while((node = traverser.advanceNode()) != null) {
-      final ObjectReference reference = node.reference;
-      Object current = reference.get();
-      for(; ; ) {
-        if(current == null || current == SyncMap.EXPUNGED) continue;
+      Node<K, V> node; long count = 0L;
+      while((node = traverser.advanceNode()) != null) {
+        final ObjectReference reference = node.reference();
+        Object current = reference.get();
+        for(; ; ) {
+          if(current == null || current == SyncMap.EXPUNGED) continue;
 
-        final Object witness = reference.compareAndExchange(current, null);
-        if(witness != current) {
-          current = witness;
-          Thread.onSpinWait();
-          continue;
+          final Object witness = reference.compareAndExchange(current, null);
+          if(witness != current) {
+            current = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          count--;
+          break;
         }
-
-        count--;
-        break;
       }
-    }
 
-    this.addCount(count);
+      this.addCount(count);
+    }
   }
 
   // Views
@@ -1334,6 +1494,35 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
     if(this.misses.sum() < this.size.sum()) return;
     this.promote();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  /* package */ @Nullable Node<K, V>[] initialize() {
+    Node<K, V>[] source, destination;
+
+    long stamp = this.stampLock.getAcquire();
+    while((destination = this.mutableTable) == null && (source = this.immutableTable).length == 0 && stamp == StampLock.DEFAULT_STAMP) {
+      final long next = StampLock.pack(StampLock.MODE_INITIALIZE);
+      final long witness = this.stampLock.compareAndExchange(stamp, next);
+      if(witness != StampLock.DEFAULT_STAMP) {
+        stamp = witness;
+        Thread.onSpinWait();
+        continue;
+      }
+
+      if(source != this.immutableTable && this.mutableTable == null) {
+        this.stampLock.reset();
+        continue;
+      }
+
+      this.mutableTable = destination = new Node[this.capacity];
+      this.amended = true;
+
+      this.stampLock.reset();
+      break;
+    }
+
+    return destination;
   }
 
   /**
@@ -1427,8 +1616,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
           continue;
         }
 
+        this.capacity = length << 1;
         this.transferIndex = length;
-        this.transferTable = destination = new Node[length << 1];
+        this.transferTable = destination = new Node[this.capacity];
         break;
       } else if(StampLock.modeOf(stamp) == StampLock.MODE_RESIZE && StampLock.stageOf(stamp) == StampLock.STAGE_RUNNING) {
         final long count = StampLock.countOf(stamp);
@@ -1573,7 +1763,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
     stamp = this.stampLock.getAcquire();
 
-    final boolean achieved = StampLock.stageOf(stamp) == StampLock.STAGE_RUNNING && this.transfer(source, destination, false) >= length;
+    final boolean achieved = StampLock.stageOf(stamp) == StampLock.STAGE_RUNNING && (this.size.sum() <= 0L || this.transfer(source, destination, false) >= length);
     if(achieved) {
       stamp = this.stampLock.getAcquire();
       for(; ; ) {
@@ -1694,7 +1884,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
               retry: while((node = next) != null) {
                 next = node.next;
 
-                final ObjectReference reference = node.reference;
+                final ObjectReference reference = node.reference();
                 if(!resize) {
                   for(; ; ) {
                     final Object current = reference.get();
@@ -1710,7 +1900,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                   }
                 }
 
-                final SyncMap.Node<K, V> cloned = new SyncMap.Node<>(node.hash, node.key, node.reference);
+                final SyncMap.Node<K, V> cloned = new SyncMap.Node<>(node.hash, node.key, node.reference());
                 if((node.hash & capacity) == 0) {
                   if(loTail == null) {
                     loHead = cloned;
@@ -1788,6 +1978,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     /* package */ static final int MODE_PROMOTE = 1;
     /* package */ static final int MODE_RESIZE = 2;
     /* package */ static final int MODE_AMEND = 3;
+    /* package */ static final int MODE_INITIALIZE = 4;
 
     /*
      * Stamp stage for bulk table updates.
@@ -1924,6 +2115,23 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       this.value = value;
     }
 
+    /* package */ boolean valueExists() {
+      final Object value;
+      return (value = this.get()) != null && value != SyncMap.EXPUNGED;
+    }
+
+    @SuppressWarnings("unchecked")
+    /* package */ <V> @Nullable V value() {
+      final Object value;
+      return (value = this.get()) != SyncMap.EXPUNGED ? (V) value : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    /* package */ <V> @NotNull V valueOr(final @NotNull V defaultValue) {
+      final Object value;
+      return ((value = this.get()) != null && value != SyncMap.EXPUNGED) ? (V) value : defaultValue;
+    }
+
     /* package */ @Nullable Object get() {
       return ObjectReference.VALUE.getAcquire(this);
     }
@@ -1948,15 +2156,35 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
    * @param <V> the value type
    */
   /* package */ static class Node<K, V> {
+    private static final VarHandle REFERENCE;
+
+    static {
+      try {
+        final MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+        REFERENCE = lookup.findVarHandle(Node.class, "reference", ObjectReference.class);
+      } catch(final Exception exception) {
+        throw new ExceptionInInitializerError(exception);
+      }
+    }
+
     /* package */ final int hash;
     /* package */ final K key;
-    /* package */ volatile ObjectReference reference;
+    /* package */ ObjectReference reference;
     /* package */ volatile Node<K, V> next;
 
     /* package */ Node(final int hash, final @UnknownNullability K key, final @Nullable ObjectReference reference) {
       this.hash = hash;
       this.key = key;
       this.reference = reference;
+    }
+
+    /* package */ @NotNull ObjectReference reference() {
+      return (ObjectReference) Node.REFERENCE.getAcquire(this);
+    }
+
+    /* package */ void reference(final @NotNull ObjectReference reference) {
+      Node.REFERENCE.setRelease(this, reference);
     }
 
     /* package */ @Nullable Node<K, V> find(final int hash, final @NotNull Object key) {
@@ -2138,7 +2366,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
       Node<K, V> node;
       while((node = this.advanceNode()) != null) {
-        final Object current = node.reference.get();
+        final Object current = node.reference().get();
         if(current == null || current == SyncMap.EXPUNGED) continue;
 
         this.next = new MapEntry(node.key, (V) current);

--- a/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
+++ b/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
@@ -1498,6 +1498,12 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     this.promote();
   }
 
+  /**
+   * Locks for the initialize operation, then creates a mutable table to
+   * allow initial writes.
+   *
+   * @return the mutable table
+   */
   @SuppressWarnings({"unchecked", "rawtypes"})
   /* package */ @Nullable Node<K, V>[] initialize() {
     Node<K, V>[] source, destination;
@@ -1578,7 +1584,6 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
    *
    * @param node the forwarding node
    * @return the next table
-   * @since 1.0.0
    */
   /* package */ Node<K, V>@Nullable [] forward(final @NotNull ForwardingNode<K, V> node) {
     if(this.amended) {

--- a/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
+++ b/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
@@ -2119,19 +2119,19 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
     /* package */ boolean valueExists() {
       final Object value;
-      return (value = this.get()) != null && value != SyncMap.EXPUNGED;
+      return (value = ObjectReference.VALUE.getOpaque(this)) != null && value != SyncMap.EXPUNGED;
     }
 
     @SuppressWarnings("unchecked")
     /* package */ <V> @Nullable V value() {
       final Object value;
-      return (value = this.get()) != SyncMap.EXPUNGED ? (V) value : null;
+      return (value = ObjectReference.VALUE.getAcquire(this)) != SyncMap.EXPUNGED ? (V) value : null;
     }
 
     @SuppressWarnings("unchecked")
     /* package */ <V> @NotNull V valueOr(final @NotNull V defaultValue) {
       final Object value;
-      return ((value = this.get()) != null && value != SyncMap.EXPUNGED) ? (V) value : defaultValue;
+      return ((value = ObjectReference.VALUE.getAcquire(this)) != null && value != SyncMap.EXPUNGED) ? (V) value : defaultValue;
     }
 
     /* package */ @Nullable Object get() {

--- a/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
+++ b/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
@@ -207,7 +207,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
    * @return true if new node was set, otherwise false
    */
   /* package */ static <K, V> boolean replaceNode(final Node<K, V>@NotNull [] table, final int index, final @Nullable Node<K, V> nextNode) {
-    return SyncMap.NODE_ARRAY.compareAndSet(table, index, (Node<K, V>) null, nextNode);
+    return SyncMap.NODE_ARRAY.compareAndExchangeRelease(table, index, (Node<K, V>) null, nextNode) == null;
   }
 
   /**
@@ -263,12 +263,14 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
    * Represents the transfer index a thread may claim a range of when
    * participating in a transfer operation.
    */
-  private transient volatile int transferIndex;
+  @SuppressWarnings("unused")
+  private transient int transferIndex;
 
   /**
    * Represents the transfer progress threads will add completed ranges to.
    */
-  private transient volatile int transferProgress;
+  @SuppressWarnings("unused")
+  private transient int transferProgress;
 
   /**
    * Represents the stamp lock for the bulk operations on the table.
@@ -369,7 +371,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         }
       }
 
-      while((node = node.next) != null) {
+      while((node = node.next()) != null) {
         if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
           return node.reference().valueExists();
         }
@@ -391,7 +393,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
           }
         }
 
-        while((node = node.next) != null) {
+        while((node = node.next()) != null) {
           if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
             exists = node.reference().valueExists();
             break retry;
@@ -427,7 +429,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         }
       }
 
-      while((node = node.next) != null) {
+      while((node = node.next()) != null) {
         if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
           return node.reference().value();
         }
@@ -449,7 +451,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
           }
         }
 
-        while((node = node.next) != null) {
+        while((node = node.next()) != null) {
           if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
             value = node.reference().value();
             break retry;
@@ -486,7 +488,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         }
       }
 
-      while((node = node.next) != null) {
+      while((node = node.next()) != null) {
         if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
           return node.reference().valueOr(defaultValue);
         }
@@ -508,7 +510,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
           }
         }
 
-        while((node = node.next) != null) {
+        while((node = node.next()) != null) {
           if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
             value = node.reference().valueOr(defaultValue);
             break retry;
@@ -543,7 +545,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         node = SyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
           if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-            node = node.next;
+            node = node.next();
             continue;
           }
 
@@ -614,11 +616,11 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
               }
 
               final Node<K, V> previousNode = node;
-              if((node = node.next) == null) {
+              if((node = node.next()) == null) {
                 next = mappingFunction.apply(key);
                 if(next == null) return null;
 
-                previousNode.next = new Node<>(hash, key, new ObjectReference(next));
+                previousNode.next(new Node<>(hash, key, new ObjectReference(next)));
                 break retry;
               }
             }
@@ -651,7 +653,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         node = SyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
           if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-            node = node.next;
+            node = node.next();
             continue;
           }
 
@@ -700,9 +702,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
                   if(next == null) {
                     if(previousNode != null) {
-                      previousNode.next = node.next;
+                      previousNode.next(node.next());
                     } else {
-                      SyncMap.setNode(mutable, index, node.next);
+                      SyncMap.setNode(mutable, index, node.next());
                     }
 
                     count = -1L;
@@ -714,7 +716,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
               previousNode = node;
 
-              if((node = node.next) == null) {
+              if((node = node.next()) == null) {
                 return null;
               }
             }
@@ -747,7 +749,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         node = SyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
           if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-            node = node.next;
+            node = node.next();
             continue;
           }
 
@@ -822,9 +824,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                     count = 1L;
                   } else if(next == null && (witness != null && witness != SyncMap.EXPUNGED)) {
                     if(previousNode != null) {
-                      previousNode.next = node.next;
+                      previousNode.next(node.next());
                     } else {
-                      SyncMap.setNode(mutable, index, node.next);
+                      SyncMap.setNode(mutable, index, node.next());
                     }
 
                     count = -1L;
@@ -836,11 +838,11 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
               previousNode = node;
 
-              if((node = node.next) == null) {
+              if((node = node.next()) == null) {
                 next = remappingFunction.apply(key, null);
                 if(next == null) return null;
 
-                previousNode.next = new Node<>(hash, key, new ObjectReference(next));
+                previousNode.next(new Node<>(hash, key, new ObjectReference(next)));
 
                 count = 1L;
                 break retry;
@@ -874,7 +876,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         node = SyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
           if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-            node = node.next;
+            node = node.next();
             continue;
           }
 
@@ -936,8 +938,8 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
               }
 
               final Node<K, V> previousNode = node;
-              if((node = node.next) == null) {
-                previousNode.next = new Node<>(hash, key, new ObjectReference(value));
+              if((node = node.next()) == null) {
+                previousNode.next(new Node<>(hash, key, new ObjectReference(value)));
                 break retry;
               }
             }
@@ -969,7 +971,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         node = SyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
           if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-            node = node.next;
+            node = node.next();
             continue;
           }
 
@@ -1033,8 +1035,8 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
               }
 
               final Node<K, V> previousNode = node;
-              if((node = node.next) == null) {
-                previousNode.next = new Node<>(hash, key, new ObjectReference(value));
+              if((node = node.next()) == null) {
+                previousNode.next(new Node<>(hash, key, new ObjectReference(value)));
                 break retry;
               }
             }
@@ -1073,8 +1075,8 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
               }
 
               final Node<K, V> previousNode = node;
-              if((node = node.next) == null) {
-                previousNode.next = new Node<>(hash, key, reference);
+              if((node = node.next()) == null) {
+                previousNode.next(new Node<>(hash, key, reference));
                 return;
               }
             }
@@ -1103,7 +1105,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         node = SyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
           if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-            node = node.next;
+            node = node.next();
             continue;
           }
 
@@ -1145,9 +1147,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                   }
 
                   if(previousNode != null) {
-                    previousNode.next = node.next;
+                    previousNode.next(node.next());
                   } else {
-                    SyncMap.setNode(mutable, index, node.next);
+                    SyncMap.setNode(mutable, index, node.next());
                   }
 
                   break retry;
@@ -1156,7 +1158,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
               previousNode = node;
 
-              if((node = node.next) == null) {
+              if((node = node.next()) == null) {
                 return null;
               }
             }
@@ -1187,7 +1189,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         node = SyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
           if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-            node = node.next;
+            node = node.next();
             continue;
           }
 
@@ -1231,9 +1233,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                   }
 
                   if(previousNode != null) {
-                    previousNode.next = node.next;
+                    previousNode.next(node.next());
                   } else {
-                    SyncMap.setNode(mutable, index, node.next);
+                    SyncMap.setNode(mutable, index, node.next());
                   }
 
                   break retry;
@@ -1242,7 +1244,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
               previousNode = node;
 
-              if((node = node.next) == null) {
+              if((node = node.next()) == null) {
                 return false;
               }
             }
@@ -1275,7 +1277,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         node = SyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
           if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-            node = node.next;
+            node = node.next();
             continue;
           }
 
@@ -1320,7 +1322,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                 }
               }
 
-              if((node = node.next) == null) {
+              if((node = node.next()) == null) {
                 return null;
               }
             }
@@ -1352,7 +1354,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         node = SyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
           if(node.hash != hash || ((nodeKey = node.key) != key && !nodeKey.equals(key))) {
-            node = node.next;
+            node = node.next();
             continue;
           }
 
@@ -1399,7 +1401,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                 }
               }
 
-              if((node = node.next) == null) {
+              if((node = node.next()) == null) {
                 return false;
               }
             }
@@ -1617,7 +1619,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         }
 
         this.capacity = length << 1;
-        this.transferIndex = length;
+        SyncMap.TRANSFER_INDEX.setRelease(this, length);
         this.transferTable = destination = new Node[this.capacity];
         break;
       } else if(StampLock.modeOf(stamp) == StampLock.MODE_RESIZE && StampLock.stageOf(stamp) == StampLock.STAGE_RUNNING) {
@@ -1691,8 +1693,8 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       }
 
       if(finalize) {
-        this.transferIndex = 0;
-        this.transferProgress = 0;
+        SyncMap.TRANSFER_INDEX.setRelease(this, 0);
+        SyncMap.TRANSFER_PROGRESS.setRelease(this, 0);
 
         this.transferTable = null;
         this.mutableTable = destination;
@@ -1733,7 +1735,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
           continue;
         }
 
-        this.transferIndex = length;
+        SyncMap.TRANSFER_INDEX.setRelease(this, length);
         this.transferTable = destination = new Node[length];
         break;
       } else if(StampLock.modeOf(stamp) == StampLock.MODE_AMEND && StampLock.stageOf(stamp) == StampLock.STAGE_RUNNING) {
@@ -1807,8 +1809,8 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       }
 
       if(finalize) {
-        this.transferIndex = 0;
-        this.transferProgress = 0;
+        SyncMap.TRANSFER_INDEX.setRelease(this, 0);
+        SyncMap.TRANSFER_PROGRESS.setRelease(this, 0);
 
         this.transferTable = null;
         this.mutableTable = destination;
@@ -1882,7 +1884,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
               Node<K, V> next = node;
 
               retry: while((node = next) != null) {
-                next = node.next;
+                next = node.next();
 
                 final ObjectReference reference = node.reference();
                 if(!resize) {
@@ -1905,7 +1907,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                   if(loTail == null) {
                     loHead = cloned;
                   } else {
-                    loTail.next = cloned;
+                    loTail.next(cloned);
                   }
 
                   loTail = cloned;
@@ -1913,7 +1915,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                   if(hiTail == null) {
                     hiHead = cloned;
                   } else {
-                    hiTail.next = cloned;
+                    hiTail.next(cloned);
                   }
 
                   hiTail = cloned;
@@ -1925,7 +1927,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                 if(hiHead != null) SyncMap.setNode(destination, i + capacity, hiHead);
               } else {
                 if(loTail != null) {
-                  loTail.next = hiHead;
+                  loTail.next(hiHead);
 
                   if(loHead != null) SyncMap.setNode(destination, i, loHead);
                 } else {
@@ -2137,7 +2139,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     }
 
     /* package */ boolean expunge() {
-      return ObjectReference.VALUE.compareAndSet(this, null, SyncMap.EXPUNGED);
+      return ObjectReference.VALUE.compareAndExchangeRelease(this, null, SyncMap.EXPUNGED) == null;
     }
 
     /* package */ @Nullable Object compareAndExchange(final @Nullable Object expect, final @Nullable Object update) {
@@ -2157,12 +2159,14 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
    */
   /* package */ static class Node<K, V> {
     private static final VarHandle REFERENCE;
+    private static final VarHandle NEXT;
 
     static {
       try {
         final MethodHandles.Lookup lookup = MethodHandles.lookup();
 
         REFERENCE = lookup.findVarHandle(Node.class, "reference", ObjectReference.class);
+        NEXT = lookup.findVarHandle(Node.class, "next", Node.class);
       } catch(final Exception exception) {
         throw new ExceptionInInitializerError(exception);
       }
@@ -2171,12 +2175,13 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     /* package */ final int hash;
     /* package */ final K key;
     /* package */ ObjectReference reference;
-    /* package */ volatile Node<K, V> next;
+    /* package */ Node<K, V> next;
 
     /* package */ Node(final int hash, final @UnknownNullability K key, final @Nullable ObjectReference reference) {
       this.hash = hash;
       this.key = key;
-      this.reference = reference;
+
+      Node.REFERENCE.setRelease(this, reference);
     }
 
     /* package */ @NotNull ObjectReference reference() {
@@ -2187,11 +2192,20 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       Node.REFERENCE.setRelease(this, reference);
     }
 
+    @SuppressWarnings("unchecked")
+    /* package */ @Nullable Node<K, V> next() {
+      return (Node<K, V>) Node.NEXT.getOpaque(this);
+    }
+
+    /* package */ void next(final @Nullable Node<K, V> node) {
+      Node.NEXT.setRelease(this, node);
+    }
+
     /* package */ @Nullable Node<K, V> find(final int hash, final @NotNull Object key) {
       Node<K, V> node = this; K nodeKey;
       do {
         if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) return node;
-      } while((node = node.next) != null);
+      } while((node = node.next()) != null);
 
       return null;
     }
@@ -2226,7 +2240,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
             return node;
           }
 
-          while((node = node.next) != null) {
+          while((node = node.next()) != null) {
             if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
               return node;
             }
@@ -2395,7 +2409,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     /* package */ final @Nullable Node<K, V> advanceNode() {
       Node<K, V> node;
       if((node = this.next) != null) {
-        node = node.next;
+        node = node.next();
       }
 
       for(; ; ) {


### PR DESCRIPTION
- Rework the benchmarks to provide more accurate results.
- Rework atomic updates to use optimal memory fences for the context they're used in.
- Initialize the mutable table on first write, instead of at construction.