### PR TITLE
improve `SyncMap`

### DIFF
--- a/collections-fastutil/benchmarks.md
+++ b/collections-fastutil/benchmarks.md
@@ -13,63 +13,63 @@ The following results were recorded on an _M4 Macbook Pro_, using 8 threads and
 100,000 entries for each benchmark:
 
 - `Int2ObjectSyncMap` **get()** speed is...
-  - 5693.1% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
-  - 6365.4% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
-  - 12794.7% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
+  - 6122.2% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
+  - 5319.3% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
+  - 7666.7% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
 
 - `Int2ObjectSyncMap` **put()** speed is...
-  - 1052.4% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
-  - 869.2% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
-  - 2309.5% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
+  - 1134.8% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
+  - 1295.5% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
+  - 2318.2% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
 
 - `Int2ObjectSyncMap` **put()** then **get()** speed is...
-  - 3221.0% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
-  - 3342.1% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
-  - 4000.0% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
+  - 3373.7% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
+  - 3190.5% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
+  - 2919.1% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
 
 ### Results
 
 ```txt
-Benchmark                            (implementation)       (mode)  (prime)  (readPercentage)  (size)   Mode  Cnt  Score    Error   Units
-Int2ObjectSyncMapBenchmark.get_only           SyncMap         none    false                50  100000  thrpt    5  1.680 ±  0.001  ops/ns
-Int2ObjectSyncMapBenchmark.get_only           SyncMap         none     true                50  100000  thrpt    5  1.680 ±  0.001  ops/ns
-Int2ObjectSyncMapBenchmark.get_only           SyncMap      presize    false                50  100000  thrpt    5  1.681 ±  0.003  ops/ns
-Int2ObjectSyncMapBenchmark.get_only           SyncMap      presize     true                50  100000  thrpt    5  1.679 ±  0.003  ops/ns
-Int2ObjectSyncMapBenchmark.get_only           SyncMap  prepopulate    false                50  100000  thrpt    5  1.752 ±  1.043  ops/ns
-Int2ObjectSyncMapBenchmark.get_only           SyncMap  prepopulate     true                50  100000  thrpt    5  2.450 ±  0.029  ops/ns
+Benchmark                            (implementation)       (mode)  (prime)  (readPercentage)  (size)   Mode  Cnt  Score   Error   Units
+Int2ObjectSyncMapBenchmark.get_only           SyncMap         none    false                50  100000  thrpt    5  1.681 ± 0.001  ops/ns
+Int2ObjectSyncMapBenchmark.get_only           SyncMap         none     true                50  100000  thrpt    5  1.680 ± 0.001  ops/ns
+Int2ObjectSyncMapBenchmark.get_only           SyncMap      presize    false                50  100000  thrpt    5  1.680 ± 0.001  ops/ns
+Int2ObjectSyncMapBenchmark.get_only           SyncMap      presize     true                50  100000  thrpt    5  1.680 ± 0.001  ops/ns
+Int2ObjectSyncMapBenchmark.get_only           SyncMap  prepopulate    false                50  100000  thrpt    5  1.629 ± 0.004  ops/ns
+Int2ObjectSyncMapBenchmark.get_only           SyncMap  prepopulate     true                50  100000  thrpt    5  1.631 ± 0.016  ops/ns
 
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.029 ±  0.032  ops/ns
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.034 ±  0.069  ops/ns
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.026 ±  0.007  ops/ns
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.036 ±  0.079  ops/ns
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.023 ±  0.023  ops/ns
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.019 ±  0.016  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.035 ± 0.062  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.027 ± 0.006  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.036 ± 0.069  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.031 ± 0.041  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.023 ± 0.011  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.021 ± 0.024  ops/ns
 
-Int2ObjectSyncMapBenchmark.get_put            SyncMap         none    false                50  100000  thrpt    5  0.621 ±  0.063  ops/ns
-Int2ObjectSyncMapBenchmark.get_put            SyncMap         none     true                50  100000  thrpt    5  0.631 ±  0.078  ops/ns
-Int2ObjectSyncMapBenchmark.get_put            SyncMap      presize    false                50  100000  thrpt    5  0.634 ±  0.081  ops/ns
-Int2ObjectSyncMapBenchmark.get_put            SyncMap      presize     true                50  100000  thrpt    5  0.654 ±  0.157  ops/ns
-Int2ObjectSyncMapBenchmark.get_put            SyncMap  prepopulate    false                50  100000  thrpt    5  0.638 ±  0.053  ops/ns
-Int2ObjectSyncMapBenchmark.get_put            SyncMap  prepopulate     true                50  100000  thrpt    5  0.615 ±  0.039  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap         none    false                50  100000  thrpt    5  0.632 ± 0.047  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap         none     true                50  100000  thrpt    5  0.660 ± 0.218  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap      presize    false                50  100000  thrpt    5  0.645 ± 0.153  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap      presize     true                50  100000  thrpt    5  0.691 ± 0.367  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap  prepopulate    false                50  100000  thrpt    5  0.630 ± 0.071  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap  prepopulate     true                50  100000  thrpt    5  0.634 ± 0.095  ops/ns
 
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap         none    false                50  100000  thrpt    5  0.019 ±  0.009  ops/ns
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap         none     true                50  100000  thrpt    5  0.019 ±  0.010  ops/ns
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap      presize    false                50  100000  thrpt    5  0.018 ±  0.014  ops/ns
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap      presize     true                50  100000  thrpt    5  0.019 ±  0.011  ops/ns
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.020 ±  0.011  ops/ns
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.015 ±  0.012  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap         none    false                50  100000  thrpt    5  0.021 ± 0.001  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap         none     true                50  100000  thrpt    5  0.019 ± 0.013  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap      presize    false                50  100000  thrpt    5  0.020 ± 0.010  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap      presize     true                50  100000  thrpt    5  0.021 ± 0.001  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.018 ± 0.014  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.021 ± 0.002  ops/ns
 
-Int2ObjectSyncMapBenchmark.put_only           SyncMap         none    false                50  100000  thrpt    5  0.223 ±  0.082  ops/ns
-Int2ObjectSyncMapBenchmark.put_only           SyncMap         none     true                50  100000  thrpt    5  0.242 ±  0.035  ops/ns
-Int2ObjectSyncMapBenchmark.put_only           SyncMap      presize    false                50  100000  thrpt    5  0.239 ±  0.128  ops/ns
-Int2ObjectSyncMapBenchmark.put_only           SyncMap      presize     true                50  100000  thrpt    5  0.252 ±  0.115  ops/ns
-Int2ObjectSyncMapBenchmark.put_only           SyncMap  prepopulate    false                50  100000  thrpt    5  0.258 ±  0.046  ops/ns
-Int2ObjectSyncMapBenchmark.put_only           SyncMap  prepopulate     true                50  100000  thrpt    5  0.506 ±  0.055  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap         none    false                50  100000  thrpt    5  0.284 ± 0.044  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap         none     true                50  100000  thrpt    5  0.278 ± 0.086  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap      presize    false                50  100000  thrpt    5  0.307 ± 0.072  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap      presize     true                50  100000  thrpt    5  0.292 ± 0.044  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap  prepopulate    false                50  100000  thrpt    5  0.289 ± 0.043  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap  prepopulate     true                50  100000  thrpt    5  0.532 ± 0.137  ops/ns
 
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.022 ±  0.001  ops/ns
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.021 ±  0.001  ops/ns
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.023 ±  0.011  ops/ns
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.026 ±  0.025  ops/ns
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.022 ±  0.005  ops/ns
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.021 ±  0.001  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.023 ± 0.010  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.023 ± 0.011  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.022 ± 0.002  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.025 ± 0.012  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.022 ± 0.007  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.022 ± 0.002  ops/ns
 ```

--- a/collections-fastutil/benchmarks.md
+++ b/collections-fastutil/benchmarks.md
@@ -13,63 +13,63 @@ The following results were recorded on an _M4 Macbook Pro_, using 8 threads and
 100,000 entries for each benchmark:
 
 - `Int2ObjectSyncMap` **get()** speed is...
-  - 6122.2% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
-  - 5319.3% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
-  - 7666.7% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
+  - 6369.2% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
+  - 4702.9% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
+  - 7676.2% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
 
 - `Int2ObjectSyncMap` **put()** speed is...
-  - 1134.8% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
-  - 1295.5% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
-  - 2318.2% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
+  - 1168.2% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
+  - 1252.2% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
+  - 2380.9% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
 
 - `Int2ObjectSyncMap` **put()** then **get()** speed is...
-  - 3373.7% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
-  - 3190.5% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
-  - 2919.1% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
+  - 3741.2% **FASTER** than `Int2ObjectMaps#synchronize()` for an empty map.
+  - 3644.4% **FASTER** than `Int2ObjectMaps#synchronize()` for a presized empty map.
+  - 2985.7% **FASTER** than `Int2ObjectMaps#synchronize()` for a full map.
 
 ### Results
 
 ```txt
 Benchmark                            (implementation)       (mode)  (prime)  (readPercentage)  (size)   Mode  Cnt  Score   Error   Units
 Int2ObjectSyncMapBenchmark.get_only           SyncMap         none    false                50  100000  thrpt    5  1.681 ± 0.001  ops/ns
-Int2ObjectSyncMapBenchmark.get_only           SyncMap         none     true                50  100000  thrpt    5  1.680 ± 0.001  ops/ns
-Int2ObjectSyncMapBenchmark.get_only           SyncMap      presize    false                50  100000  thrpt    5  1.680 ± 0.001  ops/ns
-Int2ObjectSyncMapBenchmark.get_only           SyncMap      presize     true                50  100000  thrpt    5  1.680 ± 0.001  ops/ns
-Int2ObjectSyncMapBenchmark.get_only           SyncMap  prepopulate    false                50  100000  thrpt    5  1.629 ± 0.004  ops/ns
-Int2ObjectSyncMapBenchmark.get_only           SyncMap  prepopulate     true                50  100000  thrpt    5  1.631 ± 0.016  ops/ns
+Int2ObjectSyncMapBenchmark.get_only           SyncMap         none     true                50  100000  thrpt    5  1.682 ± 0.001  ops/ns
+Int2ObjectSyncMapBenchmark.get_only           SyncMap      presize    false                50  100000  thrpt    5  1.681 ± 0.001  ops/ns
+Int2ObjectSyncMapBenchmark.get_only           SyncMap      presize     true                50  100000  thrpt    5  1.681 ± 0.002  ops/ns
+Int2ObjectSyncMapBenchmark.get_only           SyncMap  prepopulate    false                50  100000  thrpt    5  1.640 ± 0.013  ops/ns
+Int2ObjectSyncMapBenchmark.get_only           SyncMap  prepopulate     true                50  100000  thrpt    5  1.633 ± 0.010  ops/ns
 
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.035 ± 0.062  ops/ns
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.027 ± 0.006  ops/ns
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.036 ± 0.069  ops/ns
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.031 ± 0.041  ops/ns
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.023 ± 0.011  ops/ns
-Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.021 ± 0.024  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.042 ± 0.080  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.026 ± 0.002  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.026 ± 0.006  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.035 ± 0.055  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.022 ± 0.004  ops/ns
+Int2ObjectSyncMapBenchmark.get_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.021 ± 0.010  ops/ns
 
-Int2ObjectSyncMapBenchmark.get_put            SyncMap         none    false                50  100000  thrpt    5  0.632 ± 0.047  ops/ns
-Int2ObjectSyncMapBenchmark.get_put            SyncMap         none     true                50  100000  thrpt    5  0.660 ± 0.218  ops/ns
-Int2ObjectSyncMapBenchmark.get_put            SyncMap      presize    false                50  100000  thrpt    5  0.645 ± 0.153  ops/ns
-Int2ObjectSyncMapBenchmark.get_put            SyncMap      presize     true                50  100000  thrpt    5  0.691 ± 0.367  ops/ns
-Int2ObjectSyncMapBenchmark.get_put            SyncMap  prepopulate    false                50  100000  thrpt    5  0.630 ± 0.071  ops/ns
-Int2ObjectSyncMapBenchmark.get_put            SyncMap  prepopulate     true                50  100000  thrpt    5  0.634 ± 0.095  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap         none    false                50  100000  thrpt    5  0.653 ± 0.329  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap         none     true                50  100000  thrpt    5  0.646 ± 0.096  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap      presize    false                50  100000  thrpt    5  0.650 ± 0.045  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap      presize     true                50  100000  thrpt    5  0.674 ± 0.272  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap  prepopulate    false                50  100000  thrpt    5  0.648 ± 0.059  ops/ns
+Int2ObjectSyncMapBenchmark.get_put            SyncMap  prepopulate     true                50  100000  thrpt    5  0.627 ± 0.049  ops/ns
 
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap         none    false                50  100000  thrpt    5  0.021 ± 0.001  ops/ns
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap         none     true                50  100000  thrpt    5  0.019 ± 0.013  ops/ns
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap      presize    false                50  100000  thrpt    5  0.020 ± 0.010  ops/ns
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap      presize     true                50  100000  thrpt    5  0.021 ± 0.001  ops/ns
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.018 ± 0.014  ops/ns
-Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.021 ± 0.002  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap         none    false                50  100000  thrpt    5  0.017 ± 0.013  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap         none     true                50  100000  thrpt    5  0.018 ± 0.013  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap      presize    false                50  100000  thrpt    5  0.018 ± 0.011  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap      presize     true                50  100000  thrpt    5  0.018 ± 0.015  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.021 ± 0.003  ops/ns
+Int2ObjectSyncMapBenchmark.get_put    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.018 ± 0.015  ops/ns
 
-Int2ObjectSyncMapBenchmark.put_only           SyncMap         none    false                50  100000  thrpt    5  0.284 ± 0.044  ops/ns
-Int2ObjectSyncMapBenchmark.put_only           SyncMap         none     true                50  100000  thrpt    5  0.278 ± 0.086  ops/ns
-Int2ObjectSyncMapBenchmark.put_only           SyncMap      presize    false                50  100000  thrpt    5  0.307 ± 0.072  ops/ns
-Int2ObjectSyncMapBenchmark.put_only           SyncMap      presize     true                50  100000  thrpt    5  0.292 ± 0.044  ops/ns
-Int2ObjectSyncMapBenchmark.put_only           SyncMap  prepopulate    false                50  100000  thrpt    5  0.289 ± 0.043  ops/ns
-Int2ObjectSyncMapBenchmark.put_only           SyncMap  prepopulate     true                50  100000  thrpt    5  0.532 ± 0.137  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap         none    false                50  100000  thrpt    5  0.291 ± 0.121  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap         none     true                50  100000  thrpt    5  0.279 ± 0.056  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap      presize    false                50  100000  thrpt    5  0.304 ± 0.022  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap      presize     true                50  100000  thrpt    5  0.311 ± 0.080  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap  prepopulate    false                50  100000  thrpt    5  0.284 ± 0.065  ops/ns
+Int2ObjectSyncMapBenchmark.put_only           SyncMap  prepopulate     true                50  100000  thrpt    5  0.521 ± 0.028  ops/ns
 
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.023 ± 0.010  ops/ns
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.023 ± 0.011  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.024 ± 0.023  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.022 ± 0.007  ops/ns
 Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.022 ± 0.002  ops/ns
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.025 ± 0.012  ops/ns
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.022 ± 0.007  ops/ns
-Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.022 ± 0.002  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.023 ± 0.005  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.022 ± 0.001  ops/ns
+Int2ObjectSyncMapBenchmark.put_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.021 ± 0.001  ops/ns
 ```

--- a/collections-fastutil/src/main/java-templates/space/vectrix/sync/collections/fastutil/{{key}}2ObjectSyncMap.java.peb
+++ b/collections-fastutil/src/main/java-templates/space/vectrix/sync/collections/fastutil/{{key}}2ObjectSyncMap.java.peb
@@ -69,7 +69,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   /**
    * Represents the default load factor for resizing this map.
    */
-  /* package */ static final float DEFAULT_LOAD_FACTOR = 0.75F;
+  /* package */ static final float DEFAULT_LOAD_FACTOR = 0.85F;
 
   /**
    * Represents the maximum number of threads that can participate in a
@@ -146,6 +146,20 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   }
 
   /* ------------------------------- < Table > ------------------------------ */
+
+  /**
+   * Returns the {@link Node} at the given {@code index}, if present, otherwise
+   * {@code null}.
+   *
+   * @param table the node array
+   * @param index the index
+   * @param <V> the value type
+   * @return the node, or null
+   */
+  @SuppressWarnings("unchecked")
+  /* package */ static <V> @Nullable Node<V> getNodePlain(final Node<V>[] table, final int index) {
+    return (Node<V>) {{ key }}2ObjectSyncMap.NODE_ARRAY.get(table, index);
+  }
 
   /**
    * Returns the {@link Node} at the given {@code index}, if present, otherwise
@@ -261,7 +275,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   /**
    * Represents a view of the entries in this map.
    */
-  private transient @Nullable EntrySet entrySet;
+  private transient volatile @Nullable EntrySet entrySet;
 
   /* ------------------------- < Public Operations > ------------------------- */
 
@@ -359,20 +373,13 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   @Override
   public boolean containsKey(final {{ keyPrimitive }} key) {
     Node<V>[] table = this.immutableTable; int length = table.length;
-    Node<V> node, nextNode;
-    int nodeHash;
+    Node<V> node;
 
     final int hash = this.mixFunction.mix(key);
 
     if(length > 0 && (node = {{ key }}2ObjectSyncMap.getNode(table, (length - 1) & hash)) != null) {
-      if((nodeHash = node.hash) == hash) {
-        if(node.key == key) {
-          return node.reference().valueExists();
-        }
-      } else if(nodeHash < 0) {
-        if((nextNode = node.find(hash, key)) != null) {
-          return nextNode.reference().valueExists();
-        }
+      if(node.hash == hash && node.key == key) {
+        return node.reference().valueExists();
       }
 
       while((node = node.next()) != null) {
@@ -385,12 +392,14 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
     if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
       boolean exists = false;
       retry: if((node = {{ key }}2ObjectSyncMap.getNode(table, (length - 1) & hash)) != null) {
+        final int nodeHash;
         if((nodeHash = node.hash) == hash) {
           if(node.key == key) {
             exists = node.reference().valueExists();
             break retry;
           }
         } else if(nodeHash < 0) {
+          final Node<V> nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             exists = nextNode.reference().valueExists();
             break retry;
@@ -424,20 +433,13 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   @Override
   public @Nullable V get(final {{ keyPrimitive }} key) {
     Node<V>[] table = this.immutableTable; int length = table.length;
-    Node<V> node, nextNode;
-    int nodeHash;
+    Node<V> node;
 
     final int hash = this.mixFunction.mix(key);
 
     if(length > 0 && (node = {{ key }}2ObjectSyncMap.getNode(table, (length - 1) & hash)) != null) {
-      if((nodeHash = node.hash) == hash) {
-        if(node.key == key) {
-          return node.reference().value();
-        }
-      } else if(nodeHash < 0) {
-        if((nextNode = node.find(hash, key)) != null) {
-          return nextNode.reference().value();
-        }
+      if(node.hash == hash && node.key == key) {
+        return node.reference().value();
       }
 
       while((node = node.next()) != null) {
@@ -450,12 +452,14 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
     if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
       V value = null;
       retry: if((node = {{ key }}2ObjectSyncMap.getNode(table, (length - 1) & hash)) != null) {
+        final int nodeHash;
         if((nodeHash = node.hash) == hash) {
           if(node.key == key) {
             value = node.reference().value();
             break retry;
           }
         } else if(nodeHash < 0) {
+          final Node<V> nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             value = nextNode.reference().value();
             break retry;
@@ -491,20 +495,13 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
     requireNonNull(defaultValue, "defaultValue");
 
     Node<V>[] table = this.immutableTable; int length = table.length;
-    Node<V> node, nextNode;
-    int nodeHash;
+    Node<V> node;
 
     final int hash = this.mixFunction.mix(key);
 
     if(length > 0 && (node = {{ key }}2ObjectSyncMap.getNode(table, (length - 1) & hash)) != null) {
-      if((nodeHash = node.hash) == hash) {
-        if(node.key == key) {
-          return node.reference().valueOr(defaultValue);
-        }
-      } else if(nodeHash < 0) {
-        if((nextNode = node.find(hash, key)) != null) {
-          return nextNode.reference().valueOr(defaultValue);
-        }
+      if(node.hash == hash && node.key == key) {
+        return node.reference().valueOr(defaultValue);
       }
 
       while((node = node.next()) != null) {
@@ -517,12 +514,14 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
     if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
       V value = defaultValue;
       retry: if((node = {{ key }}2ObjectSyncMap.getNode(table, (length - 1) & hash)) != null) {
+        final int nodeHash;
         if((nodeHash = node.hash) == hash) {
           if(node.key == key) {
             value = node.reference().valueOr(defaultValue);
             break retry;
           }
         } else if(nodeHash < 0) {
+          final Node<V> nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             value = nextNode.reference().valueOr(defaultValue);
             break retry;
@@ -611,10 +610,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         mutable = this.forward((ForwardingNode<V>) node);
       } else {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(mutable, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && node.key == key) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous != null && previous != {{ key }}2ObjectSyncMap.EXPUNGED) return (V) previous;
@@ -634,7 +633,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
               }
 
               final Node<V> previousNode = node;
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 next = mappingFunction.apply(key);
                 if(next == null) return null;
 
@@ -718,10 +717,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         mutable = this.forward((ForwardingNode<V>) node);
       } else {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(mutable, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && node.key == key) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous != null && previous != {{ key }}2ObjectSyncMap.EXPUNGED) return (V) previous;
@@ -741,7 +740,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
               }
 
               final Node<V> previousNode = node;
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 next = mappingFunction.get(key);
                 if(next == null) return null;
 
@@ -816,10 +815,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       final int index;
       if((node = {{ key }}2ObjectSyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(mutable, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
             for(Node<V> previousNode = null; ; ) {
               if(node.hash == hash && node.key == key) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous == null || previous == {{ key }}2ObjectSyncMap.EXPUNGED) return null;
@@ -834,9 +833,9 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
                   if(next == null) {
                     if(previousNode != null) {
-                      previousNode.next(node.next());
+                      previousNode.next(node.nextPlain());
                     } else {
-                      {{ key }}2ObjectSyncMap.setNode(mutable, index, node.next());
+                      {{ key }}2ObjectSyncMap.setNode(mutable, index, node.nextPlain());
                     }
 
                     count = -1L;
@@ -848,7 +847,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
               previousNode = node;
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 return null;
               }
             }
@@ -935,10 +934,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         mutable = this.forward((ForwardingNode<V>) node);
       } else {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(mutable, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
             for(Node<V> previousNode = null; ; ) {
               if(node.hash == hash && node.key == key) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   next = remappingFunction.apply(key, previous == {{ key }}2ObjectSyncMap.EXPUNGED ? null : (V) previous);
@@ -955,9 +954,9 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                     count = 1L;
                   } else if(next == null && (witness != null && witness != {{ key }}2ObjectSyncMap.EXPUNGED)) {
                     if(previousNode != null) {
-                      previousNode.next(node.next());
+                      previousNode.next(node.nextPlain());
                     } else {
-                      {{ key }}2ObjectSyncMap.setNode(mutable, index, node.next());
+                      {{ key }}2ObjectSyncMap.setNode(mutable, index, node.nextPlain());
                     }
 
                     count = -1L;
@@ -969,7 +968,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
               previousNode = node;
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 next = remappingFunction.apply(key, null);
                 if(next == null) return null;
 
@@ -1048,10 +1047,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         mutable = this.forward((ForwardingNode<V>) node);
       } else {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(mutable, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && node.key == key) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous != null && previous != {{ key }}2ObjectSyncMap.EXPUNGED) return (V) previous;
@@ -1068,7 +1067,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
               }
 
               final Node<V> previousNode = node;
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 previousNode.next(new Node<>(hash, key, new ObjectReference(value)));
                 break retry;
               }
@@ -1142,10 +1141,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         mutable = this.forward((ForwardingNode<V>) node);
       } else {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(mutable, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && node.key == key) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   final Object witness = reference.compareAndExchange(previous, value);
@@ -1164,7 +1163,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
               }
 
               final Node<V> previousNode = node;
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 previousNode.next(new Node<>(hash, key, new ObjectReference(value)));
                 break retry;
               }
@@ -1195,7 +1194,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         table = this.forward((ForwardingNode<V>) node);
       } else {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(table, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(table, index) == node) {
             for(; ; ) {
               if(node.hash == hash && node.key == key) {
                 node.reference(reference);
@@ -1203,7 +1202,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
               }
 
               final Node<V> previousNode = node;
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 previousNode.next(new Node<>(hash, key, reference));
                 return;
               }
@@ -1265,10 +1264,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       final int index;
       if((node = {{ key }}2ObjectSyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(mutable, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
             for(Node<V> previousNode = null; ; ) {
               if(node.hash == hash && node.key == key) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object current = reference.get();
                 for(; ; ) {
                   if(current == null || current == {{ key }}2ObjectSyncMap.EXPUNGED) return null;
@@ -1281,9 +1280,9 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                   }
 
                   if(previousNode != null) {
-                    previousNode.next(node.next());
+                    previousNode.next(node.nextPlain());
                   } else {
-                    {{ key }}2ObjectSyncMap.setNode(mutable, index, node.next());
+                    {{ key }}2ObjectSyncMap.setNode(mutable, index, node.nextPlain());
                   }
 
                   break retry;
@@ -1292,7 +1291,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
               previousNode = node;
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 return null;
               }
             }
@@ -1356,10 +1355,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       final int index;
       if((node = {{ key }}2ObjectSyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(mutable, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
             for(Node<V> previousNode = null; ; ) {
               if(node.hash == hash && node.key == key) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous == null || previous == {{ key }}2ObjectSyncMap.EXPUNGED) return false;
@@ -1373,9 +1372,9 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                   }
 
                   if(previousNode != null) {
-                    previousNode.next(node.next());
+                    previousNode.next(node.nextPlain());
                   } else {
-                    {{ key }}2ObjectSyncMap.setNode(mutable, index, node.next());
+                    {{ key }}2ObjectSyncMap.setNode(mutable, index, node.nextPlain());
                   }
 
                   break retry;
@@ -1384,7 +1383,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
               previousNode = node;
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 return false;
               }
             }
@@ -1449,10 +1448,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       final int index;
       if((node = {{ key }}2ObjectSyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(mutable, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && node.key == key) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object current = reference.get();
                 for(; ; ) {
                   if(current == null || current == {{ key }}2ObjectSyncMap.EXPUNGED) return null;
@@ -1468,7 +1467,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                 }
               }
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 return null;
               }
             }
@@ -1533,10 +1532,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       final int index;
       if((node = {{ key }}2ObjectSyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if({{ key }}2ObjectSyncMap.getNode(mutable, index) == node) {
+          if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && node.key == key) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object current = reference.get();
                 for(; ; ) {
                   if(current == null || current == {{ key }}2ObjectSyncMap.EXPUNGED) return false;
@@ -1553,7 +1552,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                 }
               }
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 return false;
               }
             }
@@ -1635,7 +1634,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    */
   @Override
   public ObjectSet<{{ key }}2ObjectMap.Entry<V>> {{ keyPrimitive }}2ObjectEntrySet() {
-    if(this.entrySet != null) return this.entrySet;
+    final EntrySet entries = this.entrySet;
+    if(entries != null) return entries;
     return this.entrySet = new EntrySet();
   }
 
@@ -1743,7 +1743,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       if(!this.amended
         || (source = this.mutableTable) == null
         || (length = source.length) <= 0
-        || (this.size.sum() * this.loadFactor) < length) return;
+        || this.size.sum() < ((long) length * this.loadFactor)) return;
 
       operation = StampLock.operation(state);
       version = StampLock.version(state);
@@ -1764,8 +1764,9 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
           continue;
         }
 
-        this.capacity = length << 1;
         {{ key }}2ObjectSyncMap.TRANSFER_INDEX.setRelease(this, length);
+
+        this.capacity = length << 1;
         this.transferTable = destination = new Node[this.capacity];
         break;
       } else if(operation == StampLock.OPERATION_RESIZE
@@ -1834,8 +1835,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         }
 
         if(finalize) {
-          {{ key }}2ObjectSyncMap.TRANSFER_INDEX.setRelease(this, 0);
-          {{ key }}2ObjectSyncMap.TRANSFER_PROGRESS.setRelease(this, 0);
+          {{ key }}2ObjectSyncMap.TRANSFER_INDEX.setOpaque(this, 0);
+          {{ key }}2ObjectSyncMap.TRANSFER_PROGRESS.setOpaque(this, 0);
 
           state = StampLock.withReset(nextVersion + 1);
           this.stampLock.setVolatile(state);
@@ -1878,6 +1879,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         }
 
         {{ key }}2ObjectSyncMap.TRANSFER_INDEX.setRelease(this, length);
+
         this.transferTable = destination = new Node[length];
         break;
       } else if(operation == StampLock.OPERATION_AMEND
@@ -1948,8 +1950,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         }
 
         if(finalize) {
-          {{ key }}2ObjectSyncMap.TRANSFER_INDEX.setRelease(this, 0);
-          {{ key }}2ObjectSyncMap.TRANSFER_PROGRESS.setRelease(this, 0);
+          {{ key }}2ObjectSyncMap.TRANSFER_INDEX.setOpaque(this, 0);
+          {{ key }}2ObjectSyncMap.TRANSFER_PROGRESS.setOpaque(this, 0);
 
           state = StampLock.withReset(nextVersion + 1);
           this.stampLock.setVolatile(state);
@@ -2037,15 +2039,18 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       Node<V> node;
       int index, bound = 0;
 
+      index = (int) {{ key }}2ObjectSyncMap.TRANSFER_INDEX.getAcquire(this);
       for(; ; ) {
-        if((index = (int) {{ key }}2ObjectSyncMap.TRANSFER_INDEX.getAcquire(this)) <= 0 || finished) {
+        final int witness;
+        if(index <= 0) {
           index = -1;
           break;
-        } else if({{ key }}2ObjectSyncMap.TRANSFER_INDEX.compareAndSet(this, index, bound = (index > stride ? index - stride : 0))) {
+        } else if((witness = (int) {{ key }}2ObjectSyncMap.TRANSFER_INDEX.compareAndExchangeAcquire(this, index, bound = (index > stride ? index - stride : 0))) == index) {
           delta = index - bound;
           break;
         }
 
+        index = witness;
         Thread.onSpinWait();
       }
 
@@ -2066,15 +2071,15 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
           advance = true;
         } else {
           synchronized(node) {
-            if({{ key }}2ObjectSyncMap.getNode(source, i) == node) {
+            if({{ key }}2ObjectSyncMap.getNodePlain(source, i) == node) {
               Node<V> loHead = null, loTail = null;
               Node<V> hiHead = null, hiTail = null;
               Node<V> next = node;
 
               retry: while((node = next) != null) {
-                next = node.next();
+                next = node.nextPlain();
 
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 if(!resize) {
                   for(; ; ) {
                     final Object current = reference.get();
@@ -2090,7 +2095,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                   }
                 }
 
-                final {{ key }}2ObjectSyncMap.Node<V> cloned = new {{ key }}2ObjectSyncMap.Node<>(node.hash, node.key, node.reference());
+                final {{ key }}2ObjectSyncMap.Node<V> cloned = new {{ key }}2ObjectSyncMap.Node<>(node.hash, node.key, reference);
                 if((node.hash & capacity) == 0) {
                   if(loTail == null) {
                     loHead = cloned;
@@ -2137,14 +2142,14 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         for(; ; ) {
           if(progress >= capacity) break;
 
-          final int current = (int) {{ key }}2ObjectSyncMap.TRANSFER_PROGRESS.compareAndExchangeRelease(this, progress, progress + delta);
-          if(current == progress) {
+          final int witness = (int) {{ key }}2ObjectSyncMap.TRANSFER_PROGRESS.compareAndExchangeRelease(this, progress, progress + delta);
+          if(witness == progress) {
             progress += delta;
             delta = 0;
             break;
           }
 
-          progress = current;
+          progress = witness;
           Thread.onSpinWait();
         }
       }
@@ -2266,7 +2271,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
     }
 
     /* package */ long compareAndExchange(final long expect, final long update) {
-      return (long) StampLock.STATE.compareAndExchange(this, expect, update);
+      return (long) StampLock.STATE.compareAndExchangeAcquire(this, expect, update);
     }
   }
 
@@ -2359,7 +2364,11 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       this.hash = hash;
       this.key = key;
 
-      Node.REFERENCE.setRelease(this, reference);
+      Node.REFERENCE.setOpaque(this, reference);
+    }
+
+    /* package */ ObjectReference referencePlain() {
+      return (ObjectReference) Node.REFERENCE.get(this);
     }
 
     /* package */ ObjectReference reference() {
@@ -2371,8 +2380,13 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
     }
 
     @SuppressWarnings("unchecked")
+    /* package */ @Nullable Node<V> nextPlain() {
+      return (Node<V>) Node.NEXT.get(this);
+    }
+
+    @SuppressWarnings("unchecked")
     /* package */ @Nullable Node<V> next() {
-      return (Node<V>) Node.NEXT.getOpaque(this);
+      return (Node<V>) Node.NEXT.getAcquire(this);
     }
 
     /* package */ void next(final @Nullable Node<V> node) {

--- a/collections-fastutil/src/main/java-templates/space/vectrix/sync/collections/fastutil/{{key}}2ObjectSyncMap.java.peb
+++ b/collections-fastutil/src/main/java-templates/space/vectrix/sync/collections/fastutil/{{key}}2ObjectSyncMap.java.peb
@@ -153,12 +153,10 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    *
    * @param table the node array
    * @param index the index
-   * @param <V> the value type
    * @return the node, or null
    */
-  @SuppressWarnings("unchecked")
-  /* package */ static <V> @Nullable Node<V> getNodePlain(final Node<V>[] table, final int index) {
-    return (Node<V>) {{ key }}2ObjectSyncMap.NODE_ARRAY.get(table, index);
+  /* package */ static @Nullable Node getNodePlain(final Node[] table, final int index) {
+    return (Node) {{ key }}2ObjectSyncMap.NODE_ARRAY.get(table, index);
   }
 
   /**
@@ -167,26 +165,23 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    *
    * @param table the node array
    * @param index the index
-   * @param <V> the value type
    * @return the node, or null
    */
-  @SuppressWarnings("unchecked")
-  /* package */ static <V> @Nullable Node<V> getNode(final Node<V>[] table, final int index) {
-    return (Node<V>) {{ key }}2ObjectSyncMap.NODE_ARRAY.getAcquire(table, index);
+  /* package */ static @Nullable Node getNode(final Node[] table, final int index) {
+    return (Node) {{ key }}2ObjectSyncMap.NODE_ARRAY.getAcquire(table, index);
   }
 
   /**
    * Atomically compare and swaps the {@link Node} at the given {@code index}
    * from the {@code oldNode} to the {@code newNode}.
    *
-   * @param <V>      the value type
    * @param table    the node array
    * @param index    the index
    * @param nextNode the new node
    * @return true if new node was set, otherwise false
    */
-  /* package */ static <V> boolean replaceNode(final Node<V>[] table, final int index, final @Nullable Node<V> nextNode) {
-    return {{ key }}2ObjectSyncMap.NODE_ARRAY.compareAndExchangeRelease(table, index, (Node<V>) null, nextNode) == null;
+  /* package */ static boolean replaceNode(final Node[] table, final int index, final @Nullable Node nextNode) {
+    return {{ key }}2ObjectSyncMap.NODE_ARRAY.compareAndExchangeRelease(table, index, (Node) null, nextNode) == null;
   }
 
   /**
@@ -195,9 +190,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    * @param table the node array
    * @param index the index
    * @param node the node
-   * @param <V> the value type
    */
-  /* package */ static <V> void setNode(final Node<V>[] table, final int index, final @Nullable Node<V> node) {
+  /* package */ static void setNode(final Node[] table, final int index, final @Nullable Node node) {
     {{ key }}2ObjectSyncMap.NODE_ARRAY.setRelease(table, index, node);
   }
 
@@ -217,18 +211,18 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    * Represents an immutable hash table that allows fast retrieval and updates
    * without locking.
    */
-  /* package */ transient volatile Node<V>[] immutableTable;
+  /* package */ transient volatile Node[] immutableTable;
 
   /**
    * Represents a mutable hash table that allows updates of new nodes with
    * locking.
    */
-  private transient volatile Node<V>@Nullable [] mutableTable;
+  private transient volatile Node@Nullable [] mutableTable;
 
   /**
    * Represents a temporary transfer hash table, used in transfer operations.
    */
-  private transient volatile Node<V>@Nullable [] transferTable;
+  private transient volatile Node@Nullable [] transferTable;
 
   /**
    * Represents whether the mutable table has been amended by the immutable
@@ -344,7 +338,6 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    * @param loadFactor the load factor
    * @since 1.0.0
    */
-  @SuppressWarnings({"rawtypes", "unchecked"})
   public {{ key }}2ObjectSyncMap(final Hashing.MixFunction mixFunction, final int initialCapacity, final float loadFactor) {
     final int capacity = initialCapacity >= {{ key }}2ObjectSyncMap.MAXIMUM_CAPACITY
       ? {{ key }}2ObjectSyncMap.MAXIMUM_CAPACITY
@@ -372,8 +365,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
   @Override
   public boolean containsKey(final {{ keyPrimitive }} key) {
-    Node<V>[] table = this.immutableTable; int length = table.length;
-    Node<V> node;
+    Node[] table = this.immutableTable; int length = table.length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -399,7 +392,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
             break retry;
           }
         } else if(nodeHash < 0) {
-          final Node<V> nextNode;
+          final Node nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             exists = nextNode.reference().valueExists();
             break retry;
@@ -432,8 +425,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
   @Override
   public @Nullable V get(final {{ keyPrimitive }} key) {
-    Node<V>[] table = this.immutableTable; int length = table.length;
-    Node<V> node;
+    Node[] table = this.immutableTable; int length = table.length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -459,7 +452,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
             break retry;
           }
         } else if(nodeHash < 0) {
-          final Node<V> nextNode;
+          final Node nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             value = nextNode.reference().value();
             break retry;
@@ -494,8 +487,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   public V getOrDefault(final {{ keyPrimitive }} key, final V defaultValue) {
     requireNonNull(defaultValue, "defaultValue");
 
-    Node<V>[] table = this.immutableTable; int length = table.length;
-    Node<V> node;
+    Node[] table = this.immutableTable; int length = table.length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -521,7 +514,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
             break retry;
           }
         } else if(nodeHash < 0) {
-          final Node<V> nextNode;
+          final Node nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             value = nextNode.reference().valueOr(defaultValue);
             break retry;
@@ -548,8 +541,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   public @Nullable V computeIfAbsent(final {{ keyPrimitive }} key, final {{ keyJava }}Function<? extends @Nullable V> mappingFunction) {
     requireNonNull(mappingFunction, "mappingFunction");
 
-    Node<V>[] immutable, mutable = null; int length;
-    Node<V> node;
+    Node[] immutable, mutable = null; int length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -601,13 +594,13 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         next = mappingFunction.apply(key);
         if(next == null) return null;
 
-        if({{ key }}2ObjectSyncMap.replaceNode(mutable, index, new Node<>(hash, key, new ObjectReference(next)))) {
+        if({{ key }}2ObjectSyncMap.replaceNode(mutable, index, new Node(hash, key, new ObjectReference(next)))) {
           break;
         }
 
         Thread.onSpinWait();
       } else if(node.hash == {{ key }}2ObjectSyncMap.NODE_MOVED) {
-        mutable = this.forward((ForwardingNode<V>) node);
+        mutable = this.forward((ForwardingNode) node);
       } else {
         synchronized(node) {
           if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
@@ -632,12 +625,12 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                 }
               }
 
-              final Node<V> previousNode = node;
+              final Node previousNode = node;
               if((node = node.nextPlain()) == null) {
                 next = mappingFunction.apply(key);
                 if(next == null) return null;
 
-                previousNode.next(new Node<>(hash, key, new ObjectReference(next)));
+                previousNode.next(new Node(hash, key, new ObjectReference(next)));
                 break retry;
               }
             }
@@ -655,8 +648,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   public @Nullable V computeIfAbsent(final {{ keyPrimitive }} key, final {{ key }}2ObjectFunction<? extends @Nullable V> mappingFunction) {
     requireNonNull(mappingFunction, "mappingFunction");
 
-    Node<V>[] immutable, mutable = null; int length;
-    Node<V> node;
+    Node[] immutable, mutable = null; int length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -708,13 +701,13 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         next = mappingFunction.get(key);
         if(next == null) return null;
 
-        if({{ key }}2ObjectSyncMap.replaceNode(mutable, index, new Node<>(hash, key, new ObjectReference(next)))) {
+        if({{ key }}2ObjectSyncMap.replaceNode(mutable, index, new Node(hash, key, new ObjectReference(next)))) {
           break;
         }
 
         Thread.onSpinWait();
       } else if(node.hash == {{ key }}2ObjectSyncMap.NODE_MOVED) {
-        mutable = this.forward((ForwardingNode<V>) node);
+        mutable = this.forward((ForwardingNode) node);
       } else {
         synchronized(node) {
           if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
@@ -739,12 +732,12 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                 }
               }
 
-              final Node<V> previousNode = node;
+              final Node previousNode = node;
               if((node = node.nextPlain()) == null) {
                 next = mappingFunction.get(key);
                 if(next == null) return null;
 
-                previousNode.next(new Node<>(hash, key, new ObjectReference(next)));
+                previousNode.next(new Node(hash, key, new ObjectReference(next)));
                 break retry;
               }
             }
@@ -770,8 +763,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   public @Nullable V computeIfPresent(final {{ keyPrimitive }} key, final BiFunction<? super {{ keyObject }}, ? super V, ? extends @Nullable V> remappingFunction) {
     requireNonNull(remappingFunction, "remappingFunction");
 
-    Node<V>[] immutable, mutable; int length;
-    Node<V> node;
+    Node[] immutable, mutable; int length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -816,7 +809,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       if((node = {{ key }}2ObjectSyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
           if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
-            for(Node<V> previousNode = null; ; ) {
+            for(Node previousNode = null; ; ) {
               if(node.hash == hash && node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
@@ -865,8 +858,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   public @Nullable V compute(final {{ keyPrimitive }} key, final BiFunction<? super {{ keyObject }}, ? super @Nullable V, ? extends @Nullable V> remappingFunction) {
     requireNonNull(remappingFunction, "remappingFunction");
 
-    Node<V>[] immutable, mutable = null; int length;
-    Node<V> node;
+    Node[] immutable, mutable = null; int length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -924,18 +917,18 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         next = remappingFunction.apply(key, null);
         if(next == null) return null;
 
-        if({{ key }}2ObjectSyncMap.replaceNode(mutable, index, new Node<>(hash, key, new ObjectReference(next)))) {
+        if({{ key }}2ObjectSyncMap.replaceNode(mutable, index, new Node(hash, key, new ObjectReference(next)))) {
           count = 1L;
           break;
         }
 
         Thread.onSpinWait();
       } else if(node.hash == {{ key }}2ObjectSyncMap.NODE_MOVED) {
-        mutable = this.forward((ForwardingNode<V>) node);
+        mutable = this.forward((ForwardingNode) node);
       } else {
         synchronized(node) {
           if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
-            for(Node<V> previousNode = null; ; ) {
+            for(Node previousNode = null; ; ) {
               if(node.hash == hash && node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
@@ -972,7 +965,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                 next = remappingFunction.apply(key, null);
                 if(next == null) return null;
 
-                previousNode.next(new Node<>(hash, key, new ObjectReference(next)));
+                previousNode.next(new Node(hash, key, new ObjectReference(next)));
 
                 count = 1L;
                 break retry;
@@ -992,8 +985,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   public @Nullable V putIfAbsent(final {{ keyPrimitive }} key, final V value) {
     requireNonNull(value, "value");
 
-    Node<V>[] immutable, mutable = null; int length;
-    Node<V> node;
+    Node[] immutable, mutable = null; int length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -1038,13 +1031,13 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
         Thread.onSpinWait();
       } else if((node = {{ key }}2ObjectSyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) == null) {
-        if({{ key }}2ObjectSyncMap.replaceNode(mutable, index, new Node<>(hash, key, new ObjectReference(value)))) {
+        if({{ key }}2ObjectSyncMap.replaceNode(mutable, index, new Node(hash, key, new ObjectReference(value)))) {
           break;
         }
 
         Thread.onSpinWait();
       } else if(node.hash == {{ key }}2ObjectSyncMap.NODE_MOVED) {
-        mutable = this.forward((ForwardingNode<V>) node);
+        mutable = this.forward((ForwardingNode) node);
       } else {
         synchronized(node) {
           if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
@@ -1066,9 +1059,9 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                 }
               }
 
-              final Node<V> previousNode = node;
+              final Node previousNode = node;
               if((node = node.nextPlain()) == null) {
-                previousNode.next(new Node<>(hash, key, new ObjectReference(value)));
+                previousNode.next(new Node(hash, key, new ObjectReference(value)));
                 break retry;
               }
             }
@@ -1086,8 +1079,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   public @Nullable V put(final {{ keyPrimitive }} key, final V value) {
     requireNonNull(value, "value");
 
-    Node<V>[] immutable, mutable = null; int length;
-    Node<V> node;
+    Node[] immutable, mutable = null; int length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -1132,13 +1125,13 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
         Thread.onSpinWait();
       } else if((node = {{ key }}2ObjectSyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) == null) {
-        if({{ key }}2ObjectSyncMap.replaceNode(mutable, index, new Node<>(hash, key, new ObjectReference(value)))) {
+        if({{ key }}2ObjectSyncMap.replaceNode(mutable, index, new Node(hash, key, new ObjectReference(value)))) {
           break;
         }
 
         Thread.onSpinWait();
       } else if(node.hash == {{ key }}2ObjectSyncMap.NODE_MOVED) {
-        mutable = this.forward((ForwardingNode<V>) node);
+        mutable = this.forward((ForwardingNode) node);
       } else {
         synchronized(node) {
           if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
@@ -1162,9 +1155,9 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                 }
               }
 
-              final Node<V> previousNode = node;
+              final Node previousNode = node;
               if((node = node.nextPlain()) == null) {
-                previousNode.next(new Node<>(hash, key, new ObjectReference(value)));
+                previousNode.next(new Node(hash, key, new ObjectReference(value)));
                 break retry;
               }
             }
@@ -1178,20 +1171,20 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   }
 
   /* package */ void amendNode(final int hash, final {{ keyPrimitive }} key, final ObjectReference reference) {
-    Node<V>[] table = this.mutableTable;
+    Node[] table = this.mutableTable;
 
-    for(Node<V> node; ; ) {
+    for(Node node; ; ) {
       final int length, index;
       if(!this.amended || (table == null && (table = this.mutableTable) == null) || (length = table.length) == 0) {
         return;
       } else if((node = {{ key }}2ObjectSyncMap.getNode(table, index = (length - 1) & hash)) == null) {
-        if({{ key }}2ObjectSyncMap.replaceNode(table, index, new Node<>(hash, key, reference))) {
+        if({{ key }}2ObjectSyncMap.replaceNode(table, index, new Node(hash, key, reference))) {
           return;
         }
 
         Thread.onSpinWait();
       } else if(node.hash == {{ key }}2ObjectSyncMap.NODE_MOVED) {
-        table = this.forward((ForwardingNode<V>) node);
+        table = this.forward((ForwardingNode) node);
       } else {
         synchronized(node) {
           if({{ key }}2ObjectSyncMap.getNodePlain(table, index) == node) {
@@ -1201,9 +1194,9 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                 return;
               }
 
-              final Node<V> previousNode = node;
+              final Node previousNode = node;
               if((node = node.nextPlain()) == null) {
-                previousNode.next(new Node<>(hash, key, reference));
+                previousNode.next(new Node(hash, key, reference));
                 return;
               }
             }
@@ -1224,8 +1217,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   @Override
   @SuppressWarnings("unchecked")
   public @Nullable V remove(final {{ keyPrimitive }} key) {
-    Node<V>[] immutable, mutable; int length;
-    Node<V> node;
+    Node[] immutable, mutable; int length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -1265,7 +1258,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       if((node = {{ key }}2ObjectSyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
           if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
-            for(Node<V> previousNode = null; ; ) {
+            for(Node previousNode = null; ; ) {
               if(node.hash == hash && node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object current = reference.get();
@@ -1315,8 +1308,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   public boolean remove(final {{ keyPrimitive }} key, final Object value) {
     requireNonNull(value, "value");
 
-    Node<V>[] immutable, mutable; int length;
-    Node<V> node;
+    Node[] immutable, mutable; int length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -1356,7 +1349,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       if((node = {{ key }}2ObjectSyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
           if({{ key }}2ObjectSyncMap.getNodePlain(mutable, index) == node) {
-            for(Node<V> previousNode = null; ; ) {
+            for(Node previousNode = null; ; ) {
               if(node.hash == hash && node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
@@ -1408,8 +1401,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   public @Nullable V replace(final {{ keyPrimitive }} key, final @NonNull V value) {
     requireNonNull(value, "value");
 
-    Node<V>[] immutable, mutable; int length;
-    Node<V> node;
+    Node[] immutable, mutable; int length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -1491,8 +1484,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
     requireNonNull(oldValue, "oldValue");
     requireNonNull(newValue, "newValue");
 
-    Node<V>[] immutable, mutable; int length;
-    Node<V> node;
+    Node[] immutable, mutable; int length;
+    Node node;
 
     final int hash = this.mixFunction.mix(key);
 
@@ -1573,11 +1566,11 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
     this.promote(true);
 
-    final Node<V>[] table = this.immutableTable;
+    final Node[] table = this.immutableTable;
     if(table.length > 0) {
-      final Traverser<V> traverser = new Traverser<>(table);
+      final Traverser traverser = new Traverser(table);
 
-      Node<V> node;
+      Node node;
       while((node = traverser.advanceNode()) != null) {
         final Object current = node.referencePlain().get();
         if(current == null || current == {{ key }}2ObjectSyncMap.EXPUNGED) continue;
@@ -1591,11 +1584,11 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
   public void clear() {
     this.promote(true);
 
-    final Node<V>[] table = this.immutableTable;
+    final Node[] table = this.immutableTable;
     if(table.length > 0) {
-      final Traverser<V> traverser = new Traverser<>(table);
+      final Traverser traverser = new Traverser(table);
 
-      Node<V> node; long count = 0L;
+      Node node; long count = 0L;
       while((node = traverser.advanceNode()) != null) {
         final ObjectReference reference = node.referencePlain();
         Object current = reference.get();
@@ -1648,9 +1641,9 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    * @param node the forwarding node
    * @return the next table
    */
-  /* package */ Node<V>@Nullable [] forward(final ForwardingNode<V> node) {
+  /* package */ Node@Nullable [] forward(final ForwardingNode node) {
     if(this.amended) {
-      final Node<V>[] next = node.nextTable;
+      final Node[] next = node.nextTable;
       if(next == this.transferTable) return next;
     }
 
@@ -1688,9 +1681,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    *
    * @return the mutable table
    */
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  /* package */ Node<V>@Nullable [] initialize() {
-    Node<V>[] source, destination;
+  /* package */ Node@Nullable [] initialize() {
+    Node[] source, destination;
 
     long state; int operation, version, nextVersion;
     long next = StampLock.with(StampLock.OPERATION_INITIALIZE, StampLock.PHASE_RUNNING, 1, 0);
@@ -1734,9 +1726,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    * Creates a new mutable table with an increased capacity from the previous
    * mutable table and transfers the nodes to it.
    */
-  @SuppressWarnings({"rawtypes", "unchecked"})
   /* package */ void resize() {
-    Node<V>[] source, destination; int length;
+    Node[] source, destination; int length;
 
     long state; int operation, phase, count, version, nextVersion;
     for(state = this.stampLock.getVolatile(); ; ) {
@@ -1851,9 +1842,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    * Creates a new mutable table from the immutable table, when new nodes are
    * required and transfers the nodes to it.
    */
-  @SuppressWarnings({"rawtypes", "unchecked"})
   /* package */ void amend() {
-    Node<V>[] source, destination; int length;
+    Node[] source, destination; int length;
 
     long state; int operation, phase, count, version, nextVersion;
     for(state = this.stampLock.getVolatile(); ; ) {
@@ -1969,7 +1959,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    * @param wait whether to wait until we can promote
    */
   /* package */ void promote(final boolean wait) {
-    Node<V>[] source;
+    Node[] source;
 
     long state; int operation, version, nextVersion;
     long next = StampLock.with(StampLock.OPERATION_PROMOTE, StampLock.PHASE_RUNNING, 1, 0);
@@ -2023,7 +2013,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    * @return the transfer progress count
    */
   @SuppressWarnings({"SynchronizationOnLocalVariableOrMethodParameter"})
-  /* package */ int transfer(final Node<V>[] source, final Node<V>[] destination, final boolean resize) {
+  /* package */ int transfer(final Node[] source, final Node[] destination, final boolean resize) {
     final int capacity = source.length, nextCapacity = destination.length;
 
     int stride;
@@ -2031,12 +2021,12 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       stride = {{ key }}2ObjectSyncMap.MINIMUM_TRANSFER_STRIDE;
     }
 
-    final ForwardingNode<V> forwardingNode = new ForwardingNode<>(destination);
+    final ForwardingNode forwardingNode = new ForwardingNode(destination);
     int progress = 0, delta = 0;
     boolean finished = false;
 
     outer: for(; ; ) {
-      Node<V> node;
+      Node node;
       int index, bound = 0;
 
       index = (int) {{ key }}2ObjectSyncMap.TRANSFER_INDEX.getAcquire(this);
@@ -2072,9 +2062,9 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
         } else {
           synchronized(node) {
             if({{ key }}2ObjectSyncMap.getNodePlain(source, i) == node) {
-              Node<V> loHead = null, loTail = null;
-              Node<V> hiHead = null, hiTail = null;
-              Node<V> next = node;
+              Node loHead = null, loTail = null;
+              Node hiHead = null, hiTail = null;
+              Node next = node;
 
               retry: while((node = next) != null) {
                 next = node.nextPlain();
@@ -2095,7 +2085,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
                   }
                 }
 
-                final {{ key }}2ObjectSyncMap.Node<V> cloned = new {{ key }}2ObjectSyncMap.Node<>(node.hash, node.key, reference);
+                final {{ key }}2ObjectSyncMap.Node cloned = new {{ key }}2ObjectSyncMap.Node(node.hash, node.key, reference);
                 if((node.hash & capacity) == 0) {
                   if(loTail == null) {
                     loHead = cloned;
@@ -2337,10 +2327,8 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    * Represents a key-value pair in this map with the {@link ObjectReference}
    * holding the value. The key and hash would usually be set, except when
    * the node is special, the hash would be negative and the key {@code null}.
-   *
-   * @param <V> the value type
    */
-  /* package */ static class Node<V> {
+  /* package */ static class Node {
     private static final VarHandle REFERENCE;
     private static final VarHandle NEXT;
 
@@ -2358,7 +2346,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
     /* package */ final int hash;
     /* package */ final {{ keyPrimitive }} key;
     /* package */ @Nullable ObjectReference reference;
-    /* package */ @Nullable Node<V> next;
+    /* package */ @Nullable Node next;
 
     /* package */ Node(final int hash, final {{ keyPrimitive }} key, final @Nullable ObjectReference reference) {
       this.hash = hash;
@@ -2379,22 +2367,20 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
       Node.REFERENCE.setRelease(this, reference);
     }
 
-    @SuppressWarnings("unchecked")
-    /* package */ @Nullable Node<V> nextPlain() {
-      return (Node<V>) Node.NEXT.get(this);
+    /* package */ @Nullable Node nextPlain() {
+      return (Node) Node.NEXT.get(this);
     }
 
-    @SuppressWarnings("unchecked")
-    /* package */ @Nullable Node<V> next() {
-      return (Node<V>) Node.NEXT.getAcquire(this);
+    /* package */ @Nullable Node next() {
+      return (Node) Node.NEXT.getAcquire(this);
     }
 
-    /* package */ void next(final @Nullable Node<V> node) {
+    /* package */ void next(final @Nullable Node node) {
       Node.NEXT.setRelease(this, node);
     }
 
-    /* package */ @Nullable Node<V> find(final int hash, final {{ keyPrimitive }} key) {
-      Node<V> node = this;
+    /* package */ @Nullable Node find(final int hash, final {{ keyPrimitive }} key) {
+      Node node = this;
       do {
         if(node.hash == hash && node.key == key) return node;
       } while((node = node.next()) != null);
@@ -2405,27 +2391,25 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
   /**
    * Represents a node that has been transferred to another table.
-   *
-   * @param <V> the value type
    */
-  /* package */ static final class ForwardingNode<V> extends Node<V> {
-    /* package */ transient final Node<V>[] nextTable;
+  /* package */ static final class ForwardingNode extends Node {
+    /* package */ transient final Node[] nextTable;
 
-    /* package */ ForwardingNode(final Node<V>[] nextTable) {
+    /* package */ ForwardingNode(final Node[] nextTable) {
       super({{ key }}2ObjectSyncMap.NODE_MOVED, ({{ keyPrimitive }}) 0, null);
 
       this.nextTable = nextTable;
     }
 
     @Override
-    /* package */ @Nullable Node<V> find(final int hash, final {{ keyPrimitive }} key) {
-      Node<V> node; int length, nodeHash;
+    /* package */ @Nullable Node find(final int hash, final {{ keyPrimitive }} key) {
+      Node node; int length, nodeHash;
 
-      for(Node<V>[] table = this.nextTable; (length = table.length) > 0; ) {
+      for(Node[] table = this.nextTable; (length = table.length) > 0; ) {
         if((node = {{ key }}2ObjectSyncMap.getNode(table, (length - 1) & hash)) == null) {
           return null;
         } else if((nodeHash = node.hash) == {{ key }}2ObjectSyncMap.NODE_MOVED) {
-          table = ((ForwardingNode<V>) node).nextTable;
+          table = ((ForwardingNode) node).nextTable;
         } else {
           if(nodeHash == hash && node.key == key) {
             return node;
@@ -2548,11 +2532,11 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
    * Represents an entry {@link Iterator} that traverses the nodes in the
    * given table.
    */
-  /* package */ final class EntryIterator extends Traverser<V> implements ObjectIterator<{{ key }}2ObjectMap.Entry<V>> {
+  /* package */ final class EntryIterator extends Traverser implements ObjectIterator<{{ key }}2ObjectMap.Entry<V>> {
     private {{ key }}2ObjectMap.@Nullable Entry<V> next;
     private {{ key }}2ObjectMap.@Nullable Entry<V> current;
 
-    /* package */ EntryIterator(final Node<V>[] table) {
+    /* package */ EntryIterator(final Node[] table) {
       super(table);
 
       this.advanceEntry();
@@ -2584,7 +2568,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
     private void advanceEntry() {
       this.next = null;
 
-      Node<V> node;
+      Node node;
       while((node = this.advanceNode()) != null) {
         final Object current = node.referencePlain().get();
         if(current == null || current == {{ key }}2ObjectSyncMap.EXPUNGED) continue;
@@ -2597,22 +2581,20 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
   /**
    * Represents a simple node traversal class for a table.
-   *
-   * @param <V> the value
    */
-  /* package */ static class Traverser<V> {
-    private final Node<V>[] table;
+  /* package */ static class Traverser {
+    private final Node[] table;
     private final int length;
-    private @Nullable Node<V> next;
+    private @Nullable Node next;
     private int index;
 
-    /* package */ Traverser(final Node<V>[] table) {
+    /* package */ Traverser(final Node[] table) {
       this.table = table;
       this.length = table.length;
     }
 
-    /* package */ final @Nullable Node<V> advanceNode() {
-      Node<V> node;
+    /* package */ final @Nullable Node advanceNode() {
+      Node node;
       if((node = this.next) != null) {
         node = node.nextPlain();
       }

--- a/collections-fastutil/src/main/java-templates/space/vectrix/sync/collections/fastutil/{{key}}2ObjectSyncMap.java.peb
+++ b/collections-fastutil/src/main/java-templates/space/vectrix/sync/collections/fastutil/{{key}}2ObjectSyncMap.java.peb
@@ -379,12 +379,12 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
     if(length > 0 && (node = {{ key }}2ObjectSyncMap.getNode(table, (length - 1) & hash)) != null) {
       if(node.hash == hash && node.key == key) {
-        return node.reference().valueExists();
+        return node.referencePlain().valueExists();
       }
 
-      while((node = node.next()) != null) {
+      while((node = node.nextPlain()) != null) {
         if(node.hash == hash && node.key == key) {
-          return node.reference().valueExists();
+          return node.referencePlain().valueExists();
         }
       }
     }
@@ -439,12 +439,12 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
     if(length > 0 && (node = {{ key }}2ObjectSyncMap.getNode(table, (length - 1) & hash)) != null) {
       if(node.hash == hash && node.key == key) {
-        return node.reference().value();
+        return node.referencePlain().value();
       }
 
-      while((node = node.next()) != null) {
+      while((node = node.nextPlain()) != null) {
         if(node.hash == hash && node.key == key) {
-          return node.reference().value();
+          return node.referencePlain().value();
         }
       }
     }
@@ -501,12 +501,12 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
     if(length > 0 && (node = {{ key }}2ObjectSyncMap.getNode(table, (length - 1) & hash)) != null) {
       if(node.hash == hash && node.key == key) {
-        return node.reference().valueOr(defaultValue);
+        return node.referencePlain().valueOr(defaultValue);
       }
 
-      while((node = node.next()) != null) {
+      while((node = node.nextPlain()) != null) {
         if(node.hash == hash && node.key == key) {
-          return node.reference().valueOr(defaultValue);
+          return node.referencePlain().valueOr(defaultValue);
         }
       }
     }
@@ -1579,7 +1579,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
       Node<V> node;
       while((node = traverser.advanceNode()) != null) {
-        final Object current = node.reference().get();
+        final Object current = node.referencePlain().get();
         if(current == null || current == {{ key }}2ObjectSyncMap.EXPUNGED) continue;
 
         consumer.accept(node.key, (V) current);
@@ -1597,7 +1597,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
       Node<V> node; long count = 0L;
       while((node = traverser.advanceNode()) != null) {
-        final ObjectReference reference = node.reference();
+        final ObjectReference reference = node.referencePlain();
         Object current = reference.get();
         for(; ; ) {
           if(current == null || current == {{ key }}2ObjectSyncMap.EXPUNGED) continue;
@@ -2586,7 +2586,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
 
       Node<V> node;
       while((node = this.advanceNode()) != null) {
-        final Object current = node.reference().get();
+        final Object current = node.referencePlain().get();
         if(current == null || current == {{ key }}2ObjectSyncMap.EXPUNGED) continue;
 
         this.next = new MapEntry(node.key, (V) current);
@@ -2614,7 +2614,7 @@ public class {{ key }}2ObjectSyncMap<V> extends Abstract{{ key }}2ObjectMap<V> {
     /* package */ final @Nullable Node<V> advanceNode() {
       Node<V> node;
       if((node = this.next) != null) {
-        node = node.next();
+        node = node.nextPlain();
       }
 
       for(; ; ) {

--- a/collections/benchmarks.md
+++ b/collections/benchmarks.md
@@ -13,84 +13,84 @@ The following results were recorded on an _M4 Macbook Pro_, using 8 threads and
 100,000 entries for each benchmark:
 
 - `SyncMap` **get()** speed is...
-  - 47.8% **FASTER** than `ConcurrentHashMap` for an empty map.
-  - 48.1% **FASTER** than `ConcurrentHashMap` for a presized empty map.
-  - 21.0% **FASTER** than `ConcurrentHashMap` for a full map.
+  - 46.4% **FASTER** than `ConcurrentHashMap` for an empty map.
+  - 46.6% **FASTER** than `ConcurrentHashMap` for a presized empty map.
+  - 24.1% **FASTER** than `ConcurrentHashMap` for a full map.
 
 - `SyncMap` **put()** speed is...
-  - 23.8% **FASTER** than `ConcurrentHashMap` for an empty map.
-  - 14.5% **SLOWER** than `ConcurrentHashMap` for a presized empty map.
-  - 32.0% **FASTER** than `ConcurrentHashMap` for a full map.
+  - 61.6% **FASTER** than `ConcurrentHashMap` for an empty map.
+  - 1.9% **FASTER** than `ConcurrentHashMap` for a presized empty map.
+  - 22.9% **FASTER** than `ConcurrentHashMap` for a full map.
 
 - `SyncMap` **put()** then **get()** speed is...
-  - 109.7% **FASTER** than `ConcurrentHashMap` for an empty map.
-  - 70.4% **FASTER** than `ConcurrentHashMap` for a presized empty map.
-  - 55.1% **FASTER** than `ConcurrentHashMap` for a full map.
+  - 118.9% **FASTER** than `ConcurrentHashMap` for an empty map.
+  - 74.1% **FASTER** than `ConcurrentHashMap` for a presized empty map.
+  - 69.1% **FASTER** than `ConcurrentHashMap` for a full map.
 
 ### Results
 
 ```txt
 Benchmark                   (implementation)       (mode)  (prime)  (readPercentage)  (size)   Mode  Cnt  Score   Error   Units
-SyncMapBenchmark.get_only            SyncMap         none    false                50  100000  thrpt    5  2.411 ± 0.004  ops/ns
-SyncMapBenchmark.get_only            SyncMap         none     true                50  100000  thrpt    5  2.405 ± 0.006  ops/ns
-SyncMapBenchmark.get_only            SyncMap      presize    false                50  100000  thrpt    5  2.416 ± 0.006  ops/ns
-SyncMapBenchmark.get_only            SyncMap      presize     true                50  100000  thrpt    5  2.398 ± 0.003  ops/ns
-SyncMapBenchmark.get_only            SyncMap  prepopulate    false                50  100000  thrpt    5  1.928 ± 0.024  ops/ns
-SyncMapBenchmark.get_only            SyncMap  prepopulate     true                50  100000  thrpt    5  1.948 ± 0.035  ops/ns
+SyncMapBenchmark.get_only            SyncMap         none    false                50  100000  thrpt    5  2.381 ± 0.062  ops/ns
+SyncMapBenchmark.get_only            SyncMap         none     true                50  100000  thrpt    5  2.383 ± 0.010  ops/ns
+SyncMapBenchmark.get_only            SyncMap      presize    false                50  100000  thrpt    5  2.391 ± 0.008  ops/ns
+SyncMapBenchmark.get_only            SyncMap      presize     true                50  100000  thrpt    5  2.392 ± 0.006  ops/ns
+SyncMapBenchmark.get_only            SyncMap  prepopulate    false                50  100000  thrpt    5  1.948 ± 0.017  ops/ns
+SyncMapBenchmark.get_only            SyncMap  prepopulate     true                50  100000  thrpt    5  1.981 ± 0.035  ops/ns
 
-SyncMapBenchmark.get_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  1.631 ± 0.002  ops/ns
-SyncMapBenchmark.get_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  2.418 ± 0.002  ops/ns
-SyncMapBenchmark.get_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  1.631 ± 0.004  ops/ns
-SyncMapBenchmark.get_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  2.414 ± 0.001  ops/ns
-SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  1.593 ± 0.004  ops/ns
-SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  2.372 ± 0.049  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  1.628 ± 0.002  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  2.417 ± 0.003  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  1.632 ± 0.001  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  2.405 ± 0.010  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  1.596 ± 0.002  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  2.377 ± 0.033  ops/ns
 
-SyncMapBenchmark.get_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.026 ± 0.005  ops/ns
-SyncMapBenchmark.get_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.027 ± 0.006  ops/ns
-SyncMapBenchmark.get_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.034 ± 0.044  ops/ns
-SyncMapBenchmark.get_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.031 ± 0.043  ops/ns
-SyncMapBenchmark.get_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.026 ± 0.007  ops/ns
-SyncMapBenchmark.get_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.026 ± 0.006  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.031 ± 0.052  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.025 ± 0.001  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.025 ± 0.002  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.040 ± 0.064  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.033 ± 0.051  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.025 ± 0.005  ops/ns
 
-SyncMapBenchmark.get_put             SyncMap         none    false                50  100000  thrpt    5  0.534 ± 0.053  ops/ns
-SyncMapBenchmark.get_put             SyncMap         none     true                50  100000  thrpt    5  0.539 ± 0.064  ops/ns
-SyncMapBenchmark.get_put             SyncMap      presize    false                50  100000  thrpt    5  0.532 ± 0.042  ops/ns
-SyncMapBenchmark.get_put             SyncMap      presize     true                50  100000  thrpt    5  0.542 ± 0.041  ops/ns
-SyncMapBenchmark.get_put             SyncMap  prepopulate    false                50  100000  thrpt    5  0.526 ± 0.047  ops/ns
-SyncMapBenchmark.get_put             SyncMap  prepopulate     true                50  100000  thrpt    5  0.517 ± 0.025  ops/ns
+SyncMapBenchmark.get_put             SyncMap         none    false                50  100000  thrpt    5  0.545 ± 0.096  ops/ns
+SyncMapBenchmark.get_put             SyncMap         none     true                50  100000  thrpt    5  0.537 ± 0.051  ops/ns
+SyncMapBenchmark.get_put             SyncMap      presize    false                50  100000  thrpt    5  0.552 ± 0.086  ops/ns
+SyncMapBenchmark.get_put             SyncMap      presize     true                50  100000  thrpt    5  0.544 ± 0.033  ops/ns
+SyncMapBenchmark.get_put             SyncMap  prepopulate    false                50  100000  thrpt    5  0.570 ± 0.110  ops/ns
+SyncMapBenchmark.get_put             SyncMap  prepopulate     true                50  100000  thrpt    5  0.528 ± 0.046  ops/ns
 
-SyncMapBenchmark.get_put   ConcurrentHashMap         none    false                50  100000  thrpt    5  0.241 ± 0.002  ops/ns
-SyncMapBenchmark.get_put   ConcurrentHashMap         none     true                50  100000  thrpt    5  0.257 ± 0.006  ops/ns
-SyncMapBenchmark.get_put   ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.329 ± 0.040  ops/ns
-SyncMapBenchmark.get_put   ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.318 ± 0.006  ops/ns
-SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.339 ± 0.095  ops/ns
-SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.349 ± 0.022  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap         none    false                50  100000  thrpt    5  0.249 ± 0.005  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap         none     true                50  100000  thrpt    5  0.261 ± 0.009  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.317 ± 0.012  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.327 ± 0.036  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.337 ± 0.024  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.360 ± 0.071  ops/ns
 
-SyncMapBenchmark.get_put     SynchronizedMap         none    false                50  100000  thrpt    5  0.020 ± 0.002  ops/ns
-SyncMapBenchmark.get_put     SynchronizedMap         none     true                50  100000  thrpt    5  0.020 ± 0.009  ops/ns
-SyncMapBenchmark.get_put     SynchronizedMap      presize    false                50  100000  thrpt    5  0.021 ± 0.003  ops/ns
-SyncMapBenchmark.get_put     SynchronizedMap      presize     true                50  100000  thrpt    5  0.018 ± 0.013  ops/ns
-SyncMapBenchmark.get_put     SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.019 ± 0.012  ops/ns
-SyncMapBenchmark.get_put     SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.019 ± 0.014  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap         none    false                50  100000  thrpt    5  0.019 ± 0.012  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap         none     true                50  100000  thrpt    5  0.019 ± 0.012  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap      presize    false                50  100000  thrpt    5  0.020 ± 0.012  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap      presize     true                50  100000  thrpt    5  0.019 ± 0.012  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.018 ± 0.012  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.019 ± 0.011  ops/ns
 
-SyncMapBenchmark.put_only            SyncMap         none    false                50  100000  thrpt    5  0.255 ± 0.027  ops/ns
-SyncMapBenchmark.put_only            SyncMap         none     true                50  100000  thrpt    5  0.242 ± 0.014  ops/ns
-SyncMapBenchmark.put_only            SyncMap      presize    false                50  100000  thrpt    5  0.213 ± 0.017  ops/ns
-SyncMapBenchmark.put_only            SyncMap      presize     true                50  100000  thrpt    5  0.265 ± 0.012  ops/ns
-SyncMapBenchmark.put_only            SyncMap  prepopulate    false                50  100000  thrpt    5  0.239 ± 0.015  ops/ns
-SyncMapBenchmark.put_only            SyncMap  prepopulate     true                50  100000  thrpt    5  0.408 ± 0.053  ops/ns
+SyncMapBenchmark.put_only            SyncMap         none    false                50  100000  thrpt    5  0.242 ± 0.056  ops/ns
+SyncMapBenchmark.put_only            SyncMap         none     true                50  100000  thrpt    5  0.244 ± 0.024  ops/ns
+SyncMapBenchmark.put_only            SyncMap      presize    false                50  100000  thrpt    5  0.273 ± 0.029  ops/ns
+SyncMapBenchmark.put_only            SyncMap      presize     true                50  100000  thrpt    5  0.263 ± 0.044  ops/ns
+SyncMapBenchmark.put_only            SyncMap  prepopulate    false                50  100000  thrpt    5  0.252 ± 0.037  ops/ns
+SyncMapBenchmark.put_only            SyncMap  prepopulate     true                50  100000  thrpt    5  0.391 ± 0.057  ops/ns
 
-SyncMapBenchmark.put_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  0.206 ± 0.219  ops/ns
-SyncMapBenchmark.put_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  0.160 ± 0.025  ops/ns
-SyncMapBenchmark.put_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.273 ± 0.029  ops/ns
-SyncMapBenchmark.put_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.310 ± 0.047  ops/ns
-SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.313 ± 0.022  ops/ns
-SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.309 ± 0.027  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  0.168 ± 0.007  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  0.151 ± 0.014  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.268 ± 0.033  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.278 ± 0.043  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.318 ± 0.018  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.321 ± 0.038  ops/ns
 
-SyncMapBenchmark.put_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.032 ± 0.040  ops/ns
-SyncMapBenchmark.put_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.023 ± 0.016  ops/ns
-SyncMapBenchmark.put_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.025 ± 0.019  ops/ns
-SyncMapBenchmark.put_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.026 ± 0.025  ops/ns
-SyncMapBenchmark.put_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.021 ± 0.001  ops/ns
-SyncMapBenchmark.put_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.022 ± 0.004  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.024 ± 0.015  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.022 ± 0.006  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.023 ± 0.017  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.025 ± 0.024  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.023 ± 0.007  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.023 ± 0.009  ops/ns
 ```

--- a/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
+++ b/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
@@ -403,12 +403,12 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     K nodeKey;
     if(length > 0 && (node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
       if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-        return node.reference().valueExists();
+        return node.referencePlain().valueExists();
       }
 
-      while((node = node.next()) != null) {
+      while((node = node.nextPlain()) != null) {
         if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-          return node.reference().valueExists();
+          return node.referencePlain().valueExists();
         }
       }
     }
@@ -457,12 +457,12 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     K nodeKey;
     if(length > 0 && (node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
       if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-        return node.reference().value();
+        return node.referencePlain().value();
       }
 
-      while((node = node.next()) != null) {
+      while((node = node.nextPlain()) != null) {
         if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-          return node.reference().value();
+          return node.referencePlain().value();
         }
       }
     }
@@ -512,12 +512,12 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
     if(length > 0 && (node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
       if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-        return node.reference().valueOr(defaultValue);
+        return node.referencePlain().valueOr(defaultValue);
       }
 
-      while((node = node.next()) != null) {
+      while((node = node.nextPlain()) != null) {
         if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-          return node.reference().valueOr(defaultValue);
+          return node.referencePlain().valueOr(defaultValue);
         }
       }
     }
@@ -1457,7 +1457,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
       Node<K, V> node;
       while((node = traverser.advanceNode()) != null) {
-        final Object current = node.reference().get();
+        final Object current = node.referencePlain().get();
         if(current == null || current == SyncMap.EXPUNGED) continue;
 
         action.accept(node.key, (V) current);
@@ -1475,7 +1475,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
       Node<K, V> node; long count = 0L;
       while((node = traverser.advanceNode()) != null) {
-        final ObjectReference reference = node.reference();
+        final ObjectReference reference = node.referencePlain();
         Object current = reference.get();
         for(; ; ) {
           if(current == null || current == SyncMap.EXPUNGED) continue;
@@ -2450,7 +2450,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
       Node<K, V> node;
       while((node = this.advanceNode()) != null) {
-        final Object current = node.reference().get();
+        final Object current = node.referencePlain().get();
         if(current == null || current == SyncMap.EXPUNGED) continue;
 
         this.next = new MapEntry(node.key, (V) current);
@@ -2479,7 +2479,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     /* package */ final @Nullable Node<K, V> advanceNode() {
       Node<K, V> node;
       if((node = this.next) != null) {
-        node = node.next();
+        node = node.nextPlain();
       }
 
       for(; ; ) {

--- a/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
+++ b/collections/src/main/java/space/vectrix/sync/collections/SyncMap.java
@@ -86,7 +86,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
   /**
    * Represents the default load factor for resizing this map.
    */
-  /* package */ static final float DEFAULT_LOAD_FACTOR = 0.75F;
+  /* package */ static final float DEFAULT_LOAD_FACTOR = 0.85F;
 
   /**
    * Represents the maximum number of threads that can participate in a
@@ -163,6 +163,21 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
   }
 
   /* ------------------------------- < Table > ------------------------------ */
+
+  /**
+   * Returns the {@link Node} at the given {@code index}, if present, otherwise
+   * {@code null}.
+   *
+   * @param table the node array
+   * @param index the index
+   * @param <K> the key type
+   * @param <V> the value type
+   * @return the node, or null
+   */
+  @SuppressWarnings("unchecked")
+  /* package */ static <K, V> @Nullable Node<K, V> getNodePlain(final Node<K, V>[] table, final int index) {
+    return (Node<K, V>) SyncMap.NODE_ARRAY.get(table, index);
+  }
 
   /**
    * Returns the {@link Node} at the given {@code index}, if present, otherwise
@@ -281,7 +296,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
   /**
    * Represents a view of the entries in this map.
    */
-  private transient @Nullable EntrySet entrySet;
+  private transient volatile @Nullable EntrySet entrySet;
 
   /* ------------------------- < Public Operations > ------------------------- */
 
@@ -381,20 +396,14 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(key, "key");
 
     Node<K, V>[] table = this.immutableTable; int length = table.length;
-    Node<K, V> node, nextNode;
-    int nodeHash; K nodeKey;
+    Node<K, V> node;
 
     final int hash = this.mixFunction.mix(key.hashCode());
 
+    K nodeKey;
     if(length > 0 && (node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
-      if((nodeHash = node.hash) == hash) {
-        if((nodeKey = node.key) == key || nodeKey.equals(key)) {
-          return node.reference().valueExists();
-        }
-      } else if(nodeHash < 0) {
-        if((nextNode = node.find(hash, key)) != null) {
-          return nextNode.reference().valueExists();
-        }
+      if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
+        return node.reference().valueExists();
       }
 
       while((node = node.next()) != null) {
@@ -407,12 +416,14 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
       boolean exists = false;
       retry: if((node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
+        final int nodeHash;
         if((nodeHash = node.hash) == hash) {
           if((nodeKey = node.key) == key || nodeKey.equals(key)) {
             exists = node.reference().valueExists();
             break retry;
           }
         } else if(nodeHash < 0) {
+          final Node<K, V> nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             exists = nextNode.reference().valueExists();
             break retry;
@@ -439,20 +450,14 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(key, "key");
 
     Node<K, V>[] table = this.immutableTable; int length = table.length;
-    Node<K, V> node, nextNode;
-    int nodeHash; K nodeKey;
+    Node<K, V> node;
 
     final int hash = this.mixFunction.mix(key.hashCode());
 
+    K nodeKey;
     if(length > 0 && (node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
-      if((nodeHash = node.hash) == hash) {
-        if((nodeKey = node.key) == key || nodeKey.equals(key)) {
-          return node.reference().value();
-        }
-      } else if(nodeHash < 0) {
-        if((nextNode = node.find(hash, key)) != null) {
-          return nextNode.reference().value();
-        }
+      if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
+        return node.reference().value();
       }
 
       while((node = node.next()) != null) {
@@ -465,12 +470,14 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
       V value = null;
       retry: if((node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
+        final int nodeHash;
         if((nodeHash = node.hash) == hash) {
           if((nodeKey = node.key) == key || nodeKey.equals(key)) {
             value = node.reference().value();
             break retry;
           }
         } else if(nodeHash < 0) {
+          final Node<K, V> nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             value = nextNode.reference().value();
             break retry;
@@ -498,20 +505,14 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     requireNonNull(defaultValue, "defaultValue");
 
     Node<K, V>[] table = this.immutableTable; int length = table.length;
-    Node<K, V> node, nextNode;
-    int nodeHash; K nodeKey;
+    Node<K, V> node;
+    K nodeKey;
 
     final int hash = this.mixFunction.mix(key.hashCode());
 
     if(length > 0 && (node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
-      if((nodeHash = node.hash) == hash) {
-        if((nodeKey = node.key) == key || nodeKey.equals(key)) {
-          return node.reference().valueOr(defaultValue);
-        }
-      } else if(nodeHash < 0) {
-        if((nextNode = node.find(hash, key)) != null) {
-          return nextNode.reference().valueOr(defaultValue);
-        }
+      if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
+        return node.reference().valueOr(defaultValue);
       }
 
       while((node = node.next()) != null) {
@@ -524,12 +525,14 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
       V value = defaultValue;
       retry: if((node = SyncMap.getNode(table, (length - 1) & hash)) != null) {
+        final int nodeHash;
         if((nodeHash = node.hash) == hash) {
           if((nodeKey = node.key) == key || nodeKey.equals(key)) {
             value = node.reference().valueOr(defaultValue);
             break retry;
           }
         } else if(nodeHash < 0) {
+          final Node<K, V> nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             value = nextNode.reference().valueOr(defaultValue);
             break retry;
@@ -619,10 +622,10 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         mutable = this.forward((ForwardingNode<K, V>) node);
       } else {
         synchronized(node) {
-          if(SyncMap.getNode(mutable, index) == node) {
+          if(SyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous != null && previous != SyncMap.EXPUNGED) return (V) previous;
@@ -642,7 +645,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
               }
 
               final Node<K, V> previousNode = node;
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 next = mappingFunction.apply(key);
                 if(next == null) return null;
 
@@ -710,10 +713,10 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       final int index;
       if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if(SyncMap.getNode(mutable, index) == node) {
+          if(SyncMap.getNodePlain(mutable, index) == node) {
             for(Node<K, V> previousNode = null; ; ) {
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous == null || previous == SyncMap.EXPUNGED) return null;
@@ -728,9 +731,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
                   if(next == null) {
                     if(previousNode != null) {
-                      previousNode.next(node.next());
+                      previousNode.next(node.nextPlain());
                     } else {
-                      SyncMap.setNode(mutable, index, node.next());
+                      SyncMap.setNode(mutable, index, node.nextPlain());
                     }
 
                     count = -1L;
@@ -742,7 +745,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
               previousNode = node;
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 return null;
               }
             }
@@ -830,10 +833,10 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         mutable = this.forward((ForwardingNode<K, V>) node);
       } else {
         synchronized(node) {
-          if(SyncMap.getNode(mutable, index) == node) {
+          if(SyncMap.getNodePlain(mutable, index) == node) {
             for(Node<K, V> previousNode = null; ; ) {
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   next = remappingFunction.apply(key, previous == SyncMap.EXPUNGED ? null : (V) previous);
@@ -850,9 +853,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                     count = 1L;
                   } else if(next == null && (witness != null && witness != SyncMap.EXPUNGED)) {
                     if(previousNode != null) {
-                      previousNode.next(node.next());
+                      previousNode.next(node.nextPlain());
                     } else {
-                      SyncMap.setNode(mutable, index, node.next());
+                      SyncMap.setNode(mutable, index, node.nextPlain());
                     }
 
                     count = -1L;
@@ -864,7 +867,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
               previousNode = node;
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 next = remappingFunction.apply(key, null);
                 if(next == null) return null;
 
@@ -944,10 +947,10 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         mutable = this.forward((ForwardingNode<K, V>) node);
       } else {
         synchronized(node) {
-          if(SyncMap.getNode(mutable, index) == node) {
+          if(SyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous != null && previous != SyncMap.EXPUNGED) return (V) previous;
@@ -964,7 +967,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
               }
 
               final Node<K, V> previousNode = node;
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 previousNode.next(new Node<>(hash, key, new ObjectReference(value)));
                 break retry;
               }
@@ -1039,10 +1042,10 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         mutable = this.forward((ForwardingNode<K, V>) node);
       } else {
         synchronized(node) {
-          if(SyncMap.getNode(mutable, index) == node) {
+          if(SyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   final Object witness = reference.compareAndExchange(previous, value);
@@ -1061,7 +1064,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
               }
 
               final Node<K, V> previousNode = node;
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 previousNode.next(new Node<>(hash, key, new ObjectReference(value)));
                 break retry;
               }
@@ -1092,7 +1095,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         table = this.forward((ForwardingNode<K, V>) node);
       } else {
         synchronized(node) {
-          if(SyncMap.getNode(table, index) == node) {
+          if(SyncMap.getNodePlain(table, index) == node) {
             for(; ; ) {
               final K nodeKey;
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
@@ -1101,7 +1104,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
               }
 
               final Node<K, V> previousNode = node;
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 previousNode.next(new Node<>(hash, key, reference));
                 return;
               }
@@ -1157,10 +1160,10 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       final int index;
       if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if(SyncMap.getNode(mutable, index) == node) {
+          if(SyncMap.getNodePlain(mutable, index) == node) {
             for(Node<K, V> previousNode = null; ; ) {
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object current = reference.get();
                 for(; ; ) {
                   if(current == null || current == SyncMap.EXPUNGED) return null;
@@ -1173,9 +1176,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                   }
 
                   if(previousNode != null) {
-                    previousNode.next(node.next());
+                    previousNode.next(node.nextPlain());
                   } else {
-                    SyncMap.setNode(mutable, index, node.next());
+                    SyncMap.setNode(mutable, index, node.nextPlain());
                   }
 
                   break retry;
@@ -1184,7 +1187,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
               previousNode = node;
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 return null;
               }
             }
@@ -1242,10 +1245,10 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       final int index;
       if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if(SyncMap.getNode(mutable, index) == node) {
+          if(SyncMap.getNodePlain(mutable, index) == node) {
             for(Node<K, V> previousNode = null; ; ) {
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
                   if(previous == null || previous == SyncMap.EXPUNGED) return false;
@@ -1259,9 +1262,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                   }
 
                   if(previousNode != null) {
-                    previousNode.next(node.next());
+                    previousNode.next(node.nextPlain());
                   } else {
-                    SyncMap.setNode(mutable, index, node.next());
+                    SyncMap.setNode(mutable, index, node.nextPlain());
                   }
 
                   break retry;
@@ -1270,7 +1273,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
 
               previousNode = node;
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 return false;
               }
             }
@@ -1329,10 +1332,10 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       final int index;
       if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if(SyncMap.getNode(mutable, index) == node) {
+          if(SyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object current = reference.get();
                 for(; ; ) {
                   if(current == null || current == SyncMap.EXPUNGED) return null;
@@ -1348,7 +1351,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                 }
               }
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 return null;
               }
             }
@@ -1407,10 +1410,10 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       final int index;
       if((node = SyncMap.getNode(mutable, index = (mutable.length - 1) & hash)) != null) {
         synchronized(node) {
-          if(SyncMap.getNode(mutable, index) == node) {
+          if(SyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
               if(node.hash == hash && ((nodeKey = node.key) == key || nodeKey.equals(key))) {
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 Object current = reference.get();
                 for(; ; ) {
                   if(current == null || current == SyncMap.EXPUNGED) return false;
@@ -1427,7 +1430,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                 }
               }
 
-              if((node = node.next()) == null) {
+              if((node = node.nextPlain()) == null) {
                 return false;
               }
             }
@@ -1509,7 +1512,8 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
    */
   @Override
   public Set<Map.Entry<K, V>> entrySet() {
-    if(this.entrySet != null) return this.entrySet;
+    final EntrySet entries = this.entrySet;
+    if(entries != null) return entries;
     return this.entrySet = new EntrySet();
   }
 
@@ -1617,7 +1621,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       if(!this.amended
         || (source = this.mutableTable) == null
         || (length = source.length) <= 0
-        || (this.size.sum() * this.loadFactor) < length) return;
+        || this.size.sum() < ((long) length * this.loadFactor)) return;
 
       operation = StampLock.operation(state);
       version = StampLock.version(state);
@@ -1638,8 +1642,9 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
           continue;
         }
 
-        this.capacity = length << 1;
         SyncMap.TRANSFER_INDEX.setRelease(this, length);
+
+        this.capacity = length << 1;
         this.transferTable = destination = new Node[this.capacity];
         break;
       } else if(operation == StampLock.OPERATION_RESIZE
@@ -1708,8 +1713,8 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         }
 
         if(finalize) {
-          SyncMap.TRANSFER_INDEX.setRelease(this, 0);
-          SyncMap.TRANSFER_PROGRESS.setRelease(this, 0);
+          SyncMap.TRANSFER_INDEX.setOpaque(this, 0);
+          SyncMap.TRANSFER_PROGRESS.setOpaque(this, 0);
 
           state = StampLock.withReset(nextVersion + 1);
           this.stampLock.setVolatile(state);
@@ -1752,6 +1757,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         }
 
         SyncMap.TRANSFER_INDEX.setRelease(this, length);
+
         this.transferTable = destination = new Node[length];
         break;
       } else if(operation == StampLock.OPERATION_AMEND
@@ -1779,7 +1785,6 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     }
 
     try {
-      if(this.size.sum() <= 0L) return;
       if(this.transfer(source, destination, false) >= length) {
         state = this.stampLock.getVolatile();
         for(; ; ) {
@@ -1822,8 +1827,8 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         }
 
         if(finalize) {
-          SyncMap.TRANSFER_INDEX.setRelease(this, 0);
-          SyncMap.TRANSFER_PROGRESS.setRelease(this, 0);
+          SyncMap.TRANSFER_INDEX.setOpaque(this, 0);
+          SyncMap.TRANSFER_PROGRESS.setOpaque(this, 0);
 
           state = StampLock.withReset(nextVersion + 1);
           this.stampLock.setVolatile(state);
@@ -1911,15 +1916,18 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       Node<K, V> node;
       int index, bound = 0;
 
+      index = (int) SyncMap.TRANSFER_INDEX.getAcquire(this);
       for(; ; ) {
-        if((index = (int) SyncMap.TRANSFER_INDEX.getAcquire(this)) <= 0 || finished) {
+        final int witness;
+        if(index <= 0) {
           index = -1;
           break;
-        } else if(SyncMap.TRANSFER_INDEX.compareAndSet(this, index, bound = (index > stride ? index - stride : 0))) {
+        } else if((witness = (int) SyncMap.TRANSFER_INDEX.compareAndExchangeAcquire(this, index, bound = (index > stride ? index - stride : 0))) == index) {
           delta = index - bound;
           break;
         }
 
+        index = witness;
         Thread.onSpinWait();
       }
 
@@ -1940,15 +1948,15 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
           advance = true;
         } else {
           synchronized(node) {
-            if(SyncMap.getNode(source, i) == node) {
+            if(SyncMap.getNodePlain(source, i) == node) {
               Node<K, V> loHead = null, loTail = null;
               Node<K, V> hiHead = null, hiTail = null;
               Node<K, V> next = node;
 
               retry: while((node = next) != null) {
-                next = node.next();
+                next = node.nextPlain();
 
-                final ObjectReference reference = node.reference();
+                final ObjectReference reference = node.referencePlain();
                 if(!resize) {
                   for(; ; ) {
                     final Object current = reference.get();
@@ -1964,7 +1972,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                   }
                 }
 
-                final SyncMap.Node<K, V> cloned = new SyncMap.Node<>(node.hash, node.key, node.reference());
+                final SyncMap.Node<K, V> cloned = new SyncMap.Node<>(node.hash, node.key, reference);
                 if((node.hash & capacity) == 0) {
                   if(loTail == null) {
                     loHead = cloned;
@@ -2011,14 +2019,14 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
         for(; ; ) {
           if(progress >= capacity) break;
 
-          final int current = (int) SyncMap.TRANSFER_PROGRESS.compareAndExchangeRelease(this, progress, progress + delta);
-          if(current == progress) {
+          final int witness = (int) SyncMap.TRANSFER_PROGRESS.compareAndExchangeRelease(this, progress, progress + delta);
+          if(witness == progress) {
             progress += delta;
             delta = 0;
             break;
           }
 
-          progress = current;
+          progress = witness;
           Thread.onSpinWait();
         }
       }
@@ -2140,7 +2148,7 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     }
 
     /* package */ long compareAndExchange(final long expect, final long update) {
-      return (long) StampLock.STATE.compareAndExchange(this, expect, update);
+      return (long) StampLock.STATE.compareAndExchangeAcquire(this, expect, update);
     }
   }
 
@@ -2234,7 +2242,11 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
       this.hash = hash;
       this.key = key;
 
-      Node.REFERENCE.setRelease(this, reference);
+      Node.REFERENCE.setOpaque(this, reference);
+    }
+
+    /* package */ ObjectReference referencePlain() {
+      return (ObjectReference) Node.REFERENCE.get(this);
     }
 
     /* package */ ObjectReference reference() {
@@ -2246,8 +2258,13 @@ public class SyncMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
     }
 
     @SuppressWarnings("unchecked")
+    /* package */ @Nullable Node<K, V> nextPlain() {
+      return (Node<K, V>) Node.NEXT.get(this);
+    }
+
+    @SuppressWarnings("unchecked")
     /* package */ @Nullable Node<K, V> next() {
-      return (Node<K, V>) Node.NEXT.getOpaque(this);
+      return (Node<K, V>) Node.NEXT.getAcquire(this);
     }
 
     /* package */ void next(final @Nullable Node<K, V> node) {


### PR DESCRIPTION
Fixes the capacity requirement to trigger a resize calculation, and loosen memory fencing in areas where it is safe to do so.