### PR TITLE
add `ForwardingSyncMap`

### DIFF
--- a/build-logic/src/main/kotlin/sync.common-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/sync.common-conventions.gradle.kts
@@ -55,5 +55,3 @@ spotless {
     applyCommon()
   }
 }
-
-

--- a/collections/benchmarks.md
+++ b/collections/benchmarks.md
@@ -13,84 +13,120 @@ The following results were recorded on an _M4 Macbook Pro_, using 8 threads and
 100,000 entries for each benchmark:
 
 - `BucketSyncMap` **get()** speed is...
-  - 1.5x faster than `ConcurrentHashMap` for an empty map.
-  - 1.5x faster than `ConcurrentHashMap` for a presized empty map.
-  - 1.25x faster than `ConcurrentHashMap` for a full map.
+  - +1.35x to 0x difference in comparison to `ConcurrentHashMap` for an empty map.
+  - 0x difference in comparison to `ConcurrentHashMap` for a presized empty map.
+  - -1.2x to -1.3x in comparison to `ConcurrentHashMap` for a full map.
 
 - `BucketSyncMap` **put()** speed is...
-  - 1.5x faster than `ConcurrentHashMap` for an empty map.
-  - 1x faster than `ConcurrentHashMap` for a presized empty map.
-  - 1.25x faster than `ConcurrentHashMap` for a full map.
+  - +1.3x to +1.2x difference in comparison to `ConcurrentHashMap` for an empty map.
+  - -1.2x to -1.25x difference in comparison to `ConcurrentHashMap` for a presized empty map.
+  - +1.2x to -1.25x difference in comparison to `ConcurrentHashMap` for a full map.
 
 - `BucketSyncMap` **put()** then **get()** speed is...
-  - 2x faster than `ConcurrentHashMap` for an empty map.
-  - 1.75x faster than `ConcurrentHashMap` for a presized empty map.
-  - 1.5x faster than `ConcurrentHashMap` for a full map.
+  - +1.75x to +1.7x difference in comparison to `ConcurrentHashMap` for an empty map.
+  - +1.4x difference in comparison to `ConcurrentHashMap` for a presized empty map.
+  - +1.5x difference in comparison to `ConcurrentHashMap` for a full map.
+
+- `ForwardingSyncMap` **get()** speed is...
+  - 0x to -1.4x difference in comparison to `ConcurrentHashMap` for an empty map.
+  - 0x to -1.4x difference in comparison to `ConcurrentHashMap` for a presized empty map.
+  - -1.2x to -1.5x in comparison to `ConcurrentHashMap` for a full map.
+
+- `ForwardingSyncMap` **put()** speed is...
+  - -2.6x difference in comparison to `ConcurrentHashMap` for an empty map.
+  - -2.8x difference in comparison to `ConcurrentHashMap` for a presized empty map.
+  - +1.35x to -2.75x difference in comparison to `ConcurrentHashMap` for a full map.
+
+- `ForwardingSyncMap` **put()** then **get()** speed is...
+  - +1.75x to +1.65x difference in comparison to `ConcurrentHashMap` for an empty map.
+  - +1.45x to +1.4x difference in comparison to `ConcurrentHashMap` for a presized empty map.
+  - +1.5x difference in comparison to `ConcurrentHashMap` for a full map.
 
 ### Results
 
 ```txt
-Benchmark                         (implementation)       (mode)  (prime)  (readPercentage)  (size)   Mode  Cnt  Score   Error   Units
-BucketSyncMapBenchmark.get_only      BucketSyncMap         none    false                50  100000  thrpt    5  2.352 ± 0.075  ops/ns
-BucketSyncMapBenchmark.get_only      BucketSyncMap         none     true                50  100000  thrpt    5  2.340 ± 0.025  ops/ns
-BucketSyncMapBenchmark.get_only      BucketSyncMap      presize    false                50  100000  thrpt    5  2.346 ± 0.011  ops/ns
-BucketSyncMapBenchmark.get_only      BucketSyncMap      presize     true                50  100000  thrpt    5  2.331 ± 0.037  ops/ns
-BucketSyncMapBenchmark.get_only      BucketSyncMap  prepopulate    false                50  100000  thrpt    5  1.947 ± 0.033  ops/ns
-BucketSyncMapBenchmark.get_only      BucketSyncMap  prepopulate     true                50  100000  thrpt    5  1.936 ± 0.026  ops/ns
+Benchmark                   (implementation)       (mode)  (prime)  (readPercentage)  (size)   Mode  Cnt  Score   Error   Units
+SyncMapBenchmark.get_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  1.623 ± 0.002  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  2.378 ± 0.004  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  2.367 ± 0.013  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  2.371 ± 0.005  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  2.385 ± 0.023  ops/ns
+SyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  2.393 ± 0.006  ops/ns
 
-BucketSyncMapBenchmark.get_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  1.630 ± 0.002  ops/ns
-BucketSyncMapBenchmark.get_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  2.415 ± 0.001  ops/ns
-BucketSyncMapBenchmark.get_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  1.631 ± 0.001  ops/ns
-BucketSyncMapBenchmark.get_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  2.415 ± 0.002  ops/ns
-BucketSyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  1.593 ± 0.002  ops/ns
-BucketSyncMapBenchmark.get_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  2.376 ± 0.032  ops/ns
+SyncMapBenchmark.get_only      BucketSyncMap         none    false                50  100000  thrpt    5  2.305 ± 0.069  ops/ns
+SyncMapBenchmark.get_only      BucketSyncMap         none     true                50  100000  thrpt    5  2.307 ± 0.047  ops/ns
+SyncMapBenchmark.get_only      BucketSyncMap      presize    false                50  100000  thrpt    5  2.293 ± 0.056  ops/ns
+SyncMapBenchmark.get_only      BucketSyncMap      presize     true                50  100000  thrpt    5  2.283 ± 0.056  ops/ns
+SyncMapBenchmark.get_only      BucketSyncMap  prepopulate    false                50  100000  thrpt    5  1.898 ± 0.027  ops/ns
+SyncMapBenchmark.get_only      BucketSyncMap  prepopulate     true                50  100000  thrpt    5  1.817 ± 0.023  ops/ns
 
-BucketSyncMapBenchmark.get_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.026 ± 0.005  ops/ns
-BucketSyncMapBenchmark.get_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.031 ± 0.041  ops/ns
-BucketSyncMapBenchmark.get_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.027 ± 0.007  ops/ns
-BucketSyncMapBenchmark.get_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.028 ± 0.014  ops/ns
-BucketSyncMapBenchmark.get_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.031 ± 0.050  ops/ns
-BucketSyncMapBenchmark.get_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.025 ± 0.003  ops/ns
+SyncMapBenchmark.get_only  ForwardingSyncMap         none    false                50  100000  thrpt    5  1.618 ± 0.005  ops/ns
+SyncMapBenchmark.get_only  ForwardingSyncMap         none     true                50  100000  thrpt    5  1.623 ± 0.003  ops/ns
+SyncMapBenchmark.get_only  ForwardingSyncMap      presize    false                50  100000  thrpt    5  2.372 ± 0.017  ops/ns
+SyncMapBenchmark.get_only  ForwardingSyncMap      presize     true                50  100000  thrpt    5  1.616 ± 0.002  ops/ns
+SyncMapBenchmark.get_only  ForwardingSyncMap  prepopulate    false                50  100000  thrpt    5  1.345 ± 0.012  ops/ns
+SyncMapBenchmark.get_only  ForwardingSyncMap  prepopulate     true                50  100000  thrpt    5  1.947 ± 0.121  ops/ns
 
-BucketSyncMapBenchmark.get_put       BucketSyncMap         none    false                50  100000  thrpt    5  0.550 ± 0.109  ops/ns
-BucketSyncMapBenchmark.get_put       BucketSyncMap         none     true                50  100000  thrpt    5  0.536 ± 0.013  ops/ns
-BucketSyncMapBenchmark.get_put       BucketSyncMap      presize    false                50  100000  thrpt    5  0.575 ± 0.136  ops/ns
-BucketSyncMapBenchmark.get_put       BucketSyncMap      presize     true                50  100000  thrpt    5  0.554 ± 0.072  ops/ns
-BucketSyncMapBenchmark.get_put       BucketSyncMap  prepopulate    false                50  100000  thrpt    5  0.539 ± 0.024  ops/ns
-BucketSyncMapBenchmark.get_put       BucketSyncMap  prepopulate     true                50  100000  thrpt    5  0.533 ± 0.031  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.031 ± 0.044  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.025 ± 0.002  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.026 ± 0.003  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.025 ± 0.001  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.025 ± 0.002  ops/ns
+SyncMapBenchmark.get_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.025 ± 0.005  ops/ns
 
-BucketSyncMapBenchmark.get_put   ConcurrentHashMap         none    false                50  100000  thrpt    5  0.261 ± 0.115  ops/ns
-BucketSyncMapBenchmark.get_put   ConcurrentHashMap         none     true                50  100000  thrpt    5  0.267 ± 0.203  ops/ns
-BucketSyncMapBenchmark.get_put   ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.327 ± 0.077  ops/ns
-BucketSyncMapBenchmark.get_put   ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.324 ± 0.030  ops/ns
-BucketSyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.344 ± 0.018  ops/ns
-BucketSyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.342 ± 0.021  ops/ns
+SyncMapBenchmark.get_put       BucketSyncMap         none    false                50  100000  thrpt    5  0.559 ± 0.044  ops/ns
+SyncMapBenchmark.get_put       BucketSyncMap         none     true                50  100000  thrpt    5  0.565 ± 0.045  ops/ns
+SyncMapBenchmark.get_put       BucketSyncMap      presize    false                50  100000  thrpt    5  0.566 ± 0.105  ops/ns
+SyncMapBenchmark.get_put       BucketSyncMap      presize     true                50  100000  thrpt    5  0.558 ± 0.082  ops/ns
+SyncMapBenchmark.get_put       BucketSyncMap  prepopulate    false                50  100000  thrpt    5  0.556 ± 0.059  ops/ns
+SyncMapBenchmark.get_put       BucketSyncMap  prepopulate     true                50  100000  thrpt    5  0.544 ± 0.100  ops/ns
 
-BucketSyncMapBenchmark.get_put     SynchronizedMap         none    false                50  100000  thrpt    5  0.017 ± 0.012  ops/ns
-BucketSyncMapBenchmark.get_put     SynchronizedMap         none     true                50  100000  thrpt    5  0.017 ± 0.016  ops/ns
-BucketSyncMapBenchmark.get_put     SynchronizedMap      presize    false                50  100000  thrpt    5  0.018 ± 0.014  ops/ns
-BucketSyncMapBenchmark.get_put     SynchronizedMap      presize     true                50  100000  thrpt    5  0.017 ± 0.015  ops/ns
-BucketSyncMapBenchmark.get_put     SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.016 ± 0.014  ops/ns
-BucketSyncMapBenchmark.get_put     SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.019 ± 0.013  ops/ns
+SyncMapBenchmark.get_put   ForwardingSyncMap         none    false                50  100000  thrpt    5  0.534 ± 0.014  ops/ns
+SyncMapBenchmark.get_put   ForwardingSyncMap         none     true                50  100000  thrpt    5  0.557 ± 0.015  ops/ns
+SyncMapBenchmark.get_put   ForwardingSyncMap      presize    false                50  100000  thrpt    5  0.574 ± 0.062  ops/ns
+SyncMapBenchmark.get_put   ForwardingSyncMap      presize     true                50  100000  thrpt    5  0.557 ± 0.033  ops/ns
+SyncMapBenchmark.get_put   ForwardingSyncMap  prepopulate    false                50  100000  thrpt    5  0.562 ± 0.038  ops/ns
+SyncMapBenchmark.get_put   ForwardingSyncMap  prepopulate     true                50  100000  thrpt    5  0.562 ± 0.067  ops/ns
 
-BucketSyncMapBenchmark.put_only      BucketSyncMap         none    false                50  100000  thrpt    5  0.272 ± 0.024  ops/ns
-BucketSyncMapBenchmark.put_only      BucketSyncMap         none     true                50  100000  thrpt    5  0.264 ± 0.019  ops/ns
-BucketSyncMapBenchmark.put_only      BucketSyncMap      presize    false                50  100000  thrpt    5  0.257 ± 0.035  ops/ns
-BucketSyncMapBenchmark.put_only      BucketSyncMap      presize     true                50  100000  thrpt    5  0.253 ± 0.027  ops/ns
-BucketSyncMapBenchmark.put_only      BucketSyncMap  prepopulate    false                50  100000  thrpt    5  0.247 ± 0.048  ops/ns
-BucketSyncMapBenchmark.put_only      BucketSyncMap  prepopulate     true                50  100000  thrpt    5  0.420 ± 0.167  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap         none    false                50  100000  thrpt    5  0.270 ± 0.021  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap         none     true                50  100000  thrpt    5  0.257 ± 0.002  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.378 ± 0.096  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.362 ± 0.120  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.334 ± 0.012  ops/ns
+SyncMapBenchmark.get_put   ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.333 ± 0.007  ops/ns
 
-BucketSyncMapBenchmark.put_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  0.176 ± 0.026  ops/ns
-BucketSyncMapBenchmark.put_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  0.190 ± 0.092  ops/ns
-BucketSyncMapBenchmark.put_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.313 ± 0.046  ops/ns
-BucketSyncMapBenchmark.put_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.262 ± 0.095  ops/ns
-BucketSyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.327 ± 0.026  ops/ns
-BucketSyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.333 ± 0.124  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap         none    false                50  100000  thrpt    5  0.021 ± 0.001  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap         none     true                50  100000  thrpt    5  0.021 ± 0.001  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap      presize    false                50  100000  thrpt    5  0.019 ± 0.010  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap      presize     true                50  100000  thrpt    5  0.019 ± 0.013  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.019 ± 0.013  ops/ns
+SyncMapBenchmark.get_put     SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.018 ± 0.014  ops/ns
 
-BucketSyncMapBenchmark.put_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.026 ± 0.039  ops/ns
-BucketSyncMapBenchmark.put_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.027 ± 0.039  ops/ns
-BucketSyncMapBenchmark.put_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.024 ± 0.019  ops/ns
-BucketSyncMapBenchmark.put_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.021 ± 0.009  ops/ns
-BucketSyncMapBenchmark.put_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.022 ± 0.002  ops/ns
-BucketSyncMapBenchmark.put_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.022 ± 0.005  ops/ns
+SyncMapBenchmark.put_only      BucketSyncMap         none    false                50  100000  thrpt    5  0.270 ± 0.074  ops/ns
+SyncMapBenchmark.put_only      BucketSyncMap         none     true                50  100000  thrpt    5  0.265 ± 0.018  ops/ns
+SyncMapBenchmark.put_only      BucketSyncMap      presize    false                50  100000  thrpt    5  0.258 ± 0.033  ops/ns
+SyncMapBenchmark.put_only      BucketSyncMap      presize     true                50  100000  thrpt    5  0.256 ± 0.035  ops/ns
+SyncMapBenchmark.put_only      BucketSyncMap  prepopulate    false                50  100000  thrpt    5  0.255 ± 0.032  ops/ns
+SyncMapBenchmark.put_only      BucketSyncMap  prepopulate     true                50  100000  thrpt    5  0.395 ± 0.066  ops/ns
+
+SyncMapBenchmark.put_only  ForwardingSyncMap         none    false                50  100000  thrpt    5  0.022 ± 0.013  ops/ns
+SyncMapBenchmark.put_only  ForwardingSyncMap         none     true                50  100000  thrpt    5  0.021 ± 0.011  ops/ns
+SyncMapBenchmark.put_only  ForwardingSyncMap      presize    false                50  100000  thrpt    5  0.019 ± 0.006  ops/ns
+SyncMapBenchmark.put_only  ForwardingSyncMap      presize     true                50  100000  thrpt    5  0.019 ± 0.007  ops/ns
+SyncMapBenchmark.put_only  ForwardingSyncMap  prepopulate    false                50  100000  thrpt    5  0.021 ± 0.003  ops/ns
+SyncMapBenchmark.put_only  ForwardingSyncMap  prepopulate     true                50  100000  thrpt    5  0.464 ± 0.039  ops/ns
+
+SyncMapBenchmark.put_only  ConcurrentHashMap         none    false                50  100000  thrpt    5  0.210 ± 0.208  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap         none     true                50  100000  thrpt    5  0.196 ± 0.212  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap      presize    false                50  100000  thrpt    5  0.322 ± 0.050  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap      presize     true                50  100000  thrpt    5  0.329 ± 0.062  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate    false                50  100000  thrpt    5  0.334 ± 0.022  ops/ns
+SyncMapBenchmark.put_only  ConcurrentHashMap  prepopulate     true                50  100000  thrpt    5  0.329 ± 0.036  ops/ns
+
+SyncMapBenchmark.put_only    SynchronizedMap         none    false                50  100000  thrpt    5  0.021 ± 0.003  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap         none     true                50  100000  thrpt    5  0.022 ± 0.006  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap      presize    false                50  100000  thrpt    5  0.020 ± 0.012  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap      presize     true                50  100000  thrpt    5  0.023 ± 0.005  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.021 ± 0.006  ops/ns
+SyncMapBenchmark.put_only    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.022 ± 0.002  ops/ns
 ```

--- a/collections/readme.md
+++ b/collections/readme.md
@@ -20,6 +20,11 @@ Provides concurrent thread-safe collections for highly concurrent scenarios in J
   * Fully compatible with the Java Collections Framework (`ConcurrentMap`).
   * Delivers up to **2× higher update throughput** than `ConcurrentHashMap` under heavy contention, while matching its performance for reads and other operations.
 
+* **ForwardedSyncMap**: A performant implementation of `ConcurrentMap`.
+
+  * Fully compatible with the Java Collections Framework (`ConcurrentMap`).
+  * Delivers up to **2× higher update throughput** than `ConcurrentHashMap` under heavy contention, while being a bit slower in reads and other operations.
+
 ## Dependency
 
 Sync is available at the Maven Central Repository.

--- a/collections/src/jmh/java/space/vectrix/sync/collections/SyncMapBenchmark.java
+++ b/collections/src/jmh/java/space/vectrix/sync/collections/SyncMapBenchmark.java
@@ -49,10 +49,10 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 5)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-public class BucketSyncMapBenchmark {
+public class SyncMapBenchmark {
   @State(Scope.Benchmark)
   public static class Container {
-    @Param({ "BucketSyncMap", "ConcurrentHashMap", "SynchronizedMap" })
+    @Param({ "BucketSyncMap", "ForwardingSyncMap", "ConcurrentHashMap", "SynchronizedMap" })
     private String implementation;
 
     @Param({ "none", "presize", "prepopulate" })
@@ -73,6 +73,7 @@ public class BucketSyncMapBenchmark {
 
       switch(this.implementation) {
         case "BucketSyncMap" -> this.map = presized ? new BucketSyncMap<>(BucketSyncMap.FASTEST_SPREAD, this.size) : new BucketSyncMap<>(BucketSyncMap.FASTEST_SPREAD);
+        case "ForwardingSyncMap" -> this.map = presized ? new ForwardingSyncMap<>(HashMap::new, this.size) : new ForwardingSyncMap<>(HashMap::new);
         case "ConcurrentHashMap" -> this.map = presized ? new ConcurrentHashMap<>(this.size) : new ConcurrentHashMap<>();
         case "SynchronizedMap" -> this.map = presized
           ? Collections.synchronizedMap(new HashMap<>(this.size))

--- a/collections/src/main/java/space/vectrix/sync/collections/ForwardingSyncMap.java
+++ b/collections/src/main/java/space/vectrix/sync/collections/ForwardingSyncMap.java
@@ -1,0 +1,973 @@
+/*
+ * This file is part of sync, licensed under the MIT License.
+ *
+ * Copyright (c) 2025 vectrix.space
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package space.vectrix.sync.collections;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents a forwarding hash table capable of highly concurrent retrievals
+ * and updates, internally backed by a non-thread-safe map. The main difference
+ * is with how this map carefully manages two separate maps. One map is
+ * immutable providing efficient retrieval and updates of existing and
+ * frequently accessed key-value pairs that is fully lock-free. Whereas the
+ * mutable map allows new key-value pairs but involves a map-level lock.
+ *
+ * <p>This map is optimized for cases where updates and retrievals for existing
+ * entries is a lot faster than recently added entries. However, the
+ * performance in other cases are close to that of the backing map which is
+ * faster than a traditional map paired with a read and write lock, or maps
+ * with an exclusive lock (such as using
+ * {@link Collections#synchronizedMap(Map)}) in similar scenarios.</p>
+ *
+ * @author vectrix
+ * @param <K> the key type
+ * @param <V> the value type
+ * @since 1.1.0
+ */
+public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V>, Hash {
+
+  /* --- < Constants > ----------------------------------------------------- */
+
+  /**
+   * Represents a sentinel value for an expunged object reference.
+   */
+  private static final Object EXPUNGED = new Object();
+
+  /* --- < Fields > -------------------------------------------------------- */
+
+  /**
+   * Represents the map creation function for the backing map.
+   */
+  private final transient IntFunction<Map<K, ObjectReference>> function;
+
+  /**
+   * Represents the implicit lock for the mutable backing map.
+   */
+  private final transient Object lock = new Object();
+
+  /**
+   * Represents an immutable hash map that allows fast retrieval and updates
+   * without locking.
+   */
+  private transient volatile Map<K, ObjectReference> immutable;
+
+  /**
+   * Represents a mutable hash map that allows updates of new values with
+   * locking.
+   */
+  private transient @UnknownNullability Map<K, ObjectReference> mutable;
+
+  /**
+   * Represents whether the mutable map has been amended by the immutable map.
+   */
+  private transient volatile boolean amended;
+
+  /**
+   * Represents the amount of times the immutable map has been missed for
+   * the mutable map.
+   */
+  private transient int misses;
+
+  /**
+   * Represents a view of the entries in this map.
+   */
+  private transient @Nullable EntrySet entrySet;
+
+  /* --- < Public Operations > --------------------------------------------- */
+
+  /**
+   * Initializes a new {@link ForwardingSyncMap} with the given map creation
+   * function and {@link ForwardingSyncMap#DEFAULT_CAPACITY}.
+   *
+   * @param function the map creation function
+   * @since 1.1.0
+   */
+  public ForwardingSyncMap(final IntFunction<Map<K, ObjectReference>> function) {
+    this(function, ForwardingSyncMap.DEFAULT_CAPACITY);
+  }
+
+  /**
+   * Initializes a new {@link ForwardingSyncMap} with the given map creation
+   * function and given initial capacity.
+   *
+   * @param function the map creation function
+   * @param initialCapacity the initial capacity
+   * @since 1.1.0
+   */
+  public ForwardingSyncMap(final IntFunction<Map<K, ObjectReference>> function, final int initialCapacity) {
+    if(initialCapacity < 0) throw new IllegalArgumentException("Initial capacity must be greater than 0");
+    this.function = function;
+    this.immutable = this.function.apply(initialCapacity);
+  }
+
+  @Override
+  public int size() {
+    this.promote();
+
+    int size = 0;
+    for(final ObjectReference value : this.immutable.values()) {
+      if(value.valueExists()) size++;
+    }
+
+    return size;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    this.promote();
+
+    for(final ObjectReference value : this.immutable.values()) {
+      if(value.valueExists()) return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public boolean containsKey(final @Nullable Object key) {
+    final ObjectReference reference = this.getEntry(key);
+    return reference != null && reference.valueExists();
+  }
+
+  @Override
+  public @Nullable V get(final @Nullable Object key) {
+    final ObjectReference reference = this.getEntry(key);
+    return reference != null ? reference.value() : null;
+  }
+
+  @Override
+  public V getOrDefault(final @Nullable Object key, final V defaultValue) {
+    final ObjectReference reference = this.getEntry(key);
+    return reference != null ? reference.valueOr(defaultValue) : defaultValue;
+  }
+
+  @SuppressWarnings("SuspiciousMethodCalls")
+  private @Nullable ObjectReference getEntry(final @Nullable Object key) {
+    ObjectReference reference = this.immutable.get(key);
+    if(reference == null && this.amended) {
+      synchronized(this.lock) {
+        if((reference = this.immutable.get(key)) == null && this.amended && this.mutable != null) {
+          reference = this.mutable.get(key);
+          // The slow path should be avoided, even if the value does not match
+          // or is present. So we mark a miss to eventually promote and take a
+          // faster path.
+          this.missLocked();
+        }
+      }
+    }
+
+    return reference;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public @Nullable V computeIfAbsent(final @Nullable K key, final Function<? super K, ? extends @Nullable V> mappingFunction) {
+    requireNonNull(mappingFunction, "mappingFunction");
+
+    ObjectReference reference;
+    Object previous;
+    V next;
+
+    if((reference = this.immutable.get(key)) != null) {
+      previous = reference.get();
+      while(previous != ForwardingSyncMap.EXPUNGED) {
+        if(previous != null) return (V) previous;
+
+        next = mappingFunction.apply(key);
+        if(next == null) return null;
+
+        final Object witness = reference.compareAndExchange(null, next);
+        if(witness != null) {
+          previous = witness;
+          Thread.onSpinWait();
+          continue;
+        }
+
+        return next;
+      }
+    }
+
+    synchronized(this.lock) {
+      if((reference = this.immutable.get(key)) != null) {
+        previous = reference.get();
+        for(; ; ) {
+          if(previous != null && previous != ForwardingSyncMap.EXPUNGED) return (V) previous;
+
+          next = mappingFunction.apply(key);
+          if(next == null) return null;
+
+          final Object witness = reference.compareAndExchange(previous, next);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          if(witness == ForwardingSyncMap.EXPUNGED) {
+            this.mutable.put(key, reference);
+          }
+
+          break;
+        }
+      } else if(this.mutable != null && (reference = this.mutable.get(key)) != null) {
+        previous = reference.get();
+        for(; ; ) {
+          if(previous != null && previous != ForwardingSyncMap.EXPUNGED) return (V) previous;
+
+          next = mappingFunction.apply(key);
+          if(next == null) return null;
+
+          final Object witness = reference.compareAndExchange(previous, next);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          break;
+        }
+      } else {
+        if(!this.amended) {
+          this.amendLocked();
+          this.amended = true;
+        }
+
+        next = mappingFunction.apply(key);
+        if(next != null) this.mutable.put(key, new ObjectReference(next));
+      }
+    }
+
+    return next;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public @Nullable V computeIfPresent(final @Nullable K key, final BiFunction<? super K, ? super @Nullable V, ? extends @Nullable V> remappingFunction) {
+    requireNonNull(remappingFunction, "remappingFunction");
+
+    ObjectReference reference;
+    Object previous;
+
+    V next = null;
+
+    if((reference = this.immutable.get(key)) != null) {
+      previous = reference.get();
+      while(previous != ForwardingSyncMap.EXPUNGED) {
+        if(previous == null) return null;
+
+        next = remappingFunction.apply(key, (V) previous);
+
+        final Object witness = reference.compareAndExchange(previous, next);
+        if(witness != previous) {
+          previous = witness;
+          Thread.onSpinWait();
+          continue;
+        }
+
+        return next;
+      }
+    }
+
+    synchronized(this.lock) {
+      if((reference = this.immutable.get(key)) != null) {
+        previous = reference.get();
+        for(; ; ) {
+          if(previous == null || previous == ForwardingSyncMap.EXPUNGED) return null;
+
+          next = remappingFunction.apply(key, (V) previous);
+
+          final Object witness = reference.compareAndExchange(previous, next);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          break;
+        }
+      } else if(this.mutable != null && (reference = this.mutable.get(key)) != null) {
+        previous = reference.get();
+        for(; ; ) {
+          if(previous == null || previous == ForwardingSyncMap.EXPUNGED) return null;
+
+          next = remappingFunction.apply(key, (V) previous);
+
+          final Object witness = reference.compareAndExchange(previous, next);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          if(next == null) {
+            this.mutable.remove(key);
+            return null;
+          }
+
+          break;
+        }
+      }
+    }
+
+    return next;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public @Nullable V compute(final @Nullable K key, final BiFunction<? super K, ? super @Nullable V, ? extends @Nullable V> remappingFunction) {
+    requireNonNull(remappingFunction, "remappingFunction");
+
+    ObjectReference reference;
+    Object previous;
+    V next;
+
+    if((reference = this.immutable.get(key)) != null) {
+      previous = reference.get();
+      while(previous != ForwardingSyncMap.EXPUNGED) {
+        next = remappingFunction.apply(key, (V) previous);
+
+        final Object witness = reference.compareAndExchange(previous, next);
+        if(witness != previous) {
+          previous = witness;
+          Thread.onSpinWait();
+          continue;
+        }
+
+        return next;
+      }
+    }
+
+    synchronized(this.lock) {
+      if((reference = this.immutable.get(key)) != null) {
+        previous = reference.get();
+        for(; ; ) {
+          next = remappingFunction.apply(key, (V) previous);
+
+          final Object witness = reference.compareAndExchange(previous, next);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          if(witness == ForwardingSyncMap.EXPUNGED) {
+            this.mutable.put(key, reference);
+          }
+
+          break;
+        }
+      } else if(this.mutable != null && (reference = this.mutable.get(key)) != null) {
+        previous = reference.get();
+        for(; ; ) {
+          next = remappingFunction.apply(key, (V) previous);
+
+          final Object witness = reference.compareAndExchange(previous, next);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          if(next == null) {
+            this.mutable.remove(key);
+            return null;
+          }
+
+          break;
+        }
+      } else {
+        if(!this.amended) {
+          this.amendLocked();
+          this.amended = true;
+        }
+
+        next = remappingFunction.apply(key, null);
+        if(next != null) this.mutable.put(key, new ObjectReference(next));
+      }
+    }
+
+    return next;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public @Nullable V putIfAbsent(final @Nullable K key, final V value) {
+    requireNonNull(value, "value");
+
+    ObjectReference reference;
+    Object previous;
+
+    if((reference = this.immutable.get(key)) != null) {
+      previous = reference.get();
+      while(previous != ForwardingSyncMap.EXPUNGED) {
+        if(previous != null) return (V) previous;
+
+        final Object witness = reference.compareAndExchange(null, value);
+        if(witness != null) {
+          previous = witness;
+          Thread.onSpinWait();
+          continue;
+        }
+
+        return null;
+      }
+    }
+
+    synchronized(this.lock) {
+      if((reference = this.immutable.get(key)) != null) {
+        previous = reference.get();
+        for(; ; ) {
+          if(previous != null && previous != ForwardingSyncMap.EXPUNGED) return (V) previous;
+
+          final Object witness = reference.compareAndExchange(previous, value);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          if(witness == ForwardingSyncMap.EXPUNGED) {
+            this.mutable.put(key, reference);
+          }
+
+          break;
+        }
+      } else if(this.mutable != null && (reference = this.mutable.get(key)) != null) {
+        previous = reference.get();
+        for(; ; ) {
+          if(previous != null && previous != ForwardingSyncMap.EXPUNGED) return (V) previous;
+
+          final Object witness = reference.compareAndExchange(previous, value);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          break;
+        }
+      } else {
+        if(!this.amended) {
+          this.amendLocked();
+          this.amended = true;
+        }
+
+        assert this.mutable != null;
+        this.mutable.put(key, new ObjectReference(value));
+        return null;
+      }
+    }
+
+    return (V) previous;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public @Nullable V put(final @Nullable K key, final V value) {
+    requireNonNull(value, "value");
+
+    ObjectReference reference;
+    Object previous;
+
+    if((reference = this.immutable.get(key)) != null) {
+      previous = reference.get();
+      while(previous != ForwardingSyncMap.EXPUNGED) {
+        final Object witness = reference.compareAndExchange(previous, value);
+        if(witness != previous) {
+          previous = witness;
+          Thread.onSpinWait();
+          continue;
+        }
+
+        return (V) previous;
+      }
+    }
+
+    synchronized(this.lock) {
+      if((reference = this.immutable.get(key)) != null) {
+        previous = reference.get();
+        for(; ; ) {
+          final Object witness = reference.compareAndExchange(previous, value);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          if(witness == ForwardingSyncMap.EXPUNGED) {
+            this.mutable.put(key, reference);
+          }
+
+          break;
+        }
+      } else if(this.mutable != null && (reference = this.mutable.get(key)) != null) {
+        previous = reference.get();
+        for(; ; ) {
+          final Object witness = reference.compareAndExchange(previous, value);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          break;
+        }
+      } else {
+        if(!this.amended) {
+          this.amendLocked();
+          this.amended = true;
+        }
+
+        assert this.mutable != null;
+        this.mutable.put(key, new ObjectReference(value));
+        return null;
+      }
+    }
+
+    return (V) previous;
+  }
+
+  @Override
+  @SuppressWarnings({"unchecked", "SuspiciousMethodCalls"})
+  public @Nullable V remove(final @Nullable Object key) {
+    ObjectReference reference;
+    Object previous;
+
+    if((reference = this.immutable.get(key)) != null) {
+      previous = reference.get();
+      while(previous != null && previous != ForwardingSyncMap.EXPUNGED) {
+        final Object witness = reference.compareAndExchange(previous, null);
+        if(witness != previous) {
+          previous = witness;
+          Thread.onSpinWait();
+          continue;
+        }
+
+        return (V) previous;
+      }
+    }
+
+    synchronized(this.lock) {
+      if(this.immutable.get(key) == null && this.amended) {
+        reference = this.mutable.remove(key);
+        return reference.value();
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  @SuppressWarnings("SuspiciousMethodCalls")
+  public boolean remove(final @Nullable Object key, final Object value) {
+    ObjectReference reference;
+    Object previous;
+
+    if((reference = this.immutable.get(key)) != null) {
+      previous = reference.get();
+      while(previous != null && previous != ForwardingSyncMap.EXPUNGED) {
+        if(!Objects.equals(previous, value)) return false;
+
+        final Object witness = reference.compareAndExchange(previous, null);
+        if(witness != previous) {
+          previous = witness;
+          Thread.onSpinWait();
+          continue;
+        }
+
+        return true;
+      }
+    }
+
+    synchronized(this.lock) {
+      if(this.immutable.get(key) == null && this.amended && (reference = this.mutable.get(key)) != null) {
+        previous = reference.get();
+        while(previous != null) {
+          if(!Objects.equals(previous, value)) return false;
+
+          final Object witness = reference.compareAndExchange(previous, null);
+          if(witness != previous) {
+            previous = witness;
+            Thread.onSpinWait();
+            continue;
+          }
+
+          break;
+        }
+
+        this.mutable.remove(key);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public @Nullable V replace(final @Nullable K key, final V value) {
+    requireNonNull(value, "value");
+
+    final ObjectReference reference = this.getEntry(key);
+    if(reference != null) {
+      Object previous = reference.get();
+      for(; ; ) {
+        if(previous == null || previous == ForwardingSyncMap.EXPUNGED) return null;
+
+        final Object witness = reference.compareAndExchange(previous, value);
+        if(witness != previous) {
+          previous = witness;
+          Thread.onSpinWait();
+          continue;
+        }
+
+        return (V) previous;
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  public boolean replace(final @Nullable K key, final V oldValue, final V newValue) {
+    requireNonNull(oldValue, "oldValue");
+    requireNonNull(newValue, "newValue");
+
+    final ObjectReference reference = this.getEntry(key);
+    if(reference != null) {
+      Object previous = reference.get();
+      for(; ; ) {
+        if(previous == null || previous == ForwardingSyncMap.EXPUNGED) return false;
+        if(!Objects.equals(previous, oldValue)) return false;
+
+        final Object witness = reference.compareAndExchange(previous, newValue);
+        if(witness != previous) {
+          previous = witness;
+          Thread.onSpinWait();
+          continue;
+        }
+
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  // Bulk Operations
+
+  @Override
+  public void forEach(final BiConsumer<? super K, ? super V> action) {
+    requireNonNull(action, "action");
+    this.promote();
+
+    V value;
+    for(final Map.Entry<K, ObjectReference> that : this.immutable.entrySet()) {
+      if((value = that.getValue().value()) != null) {
+        action.accept(that.getKey(), value);
+      }
+    }
+  }
+
+  @Override
+  public void clear() {
+    synchronized(this.lock) {
+      this.immutable = this.function.apply(this.immutable.size());
+      this.mutable = null;
+      this.amended = false;
+      this.misses = 0;
+    }
+  }
+
+  // Views
+
+  @Override
+  public Set<Map.Entry<K, V>> entrySet() {
+    if(this.entrySet != null) return this.entrySet;
+    return this.entrySet = new EntrySet();
+  }
+
+  /* --- < Private Operations > -------------------------------------------- */
+
+  /**
+   * Promotes the mutable map to the immutable map if the mutable map has been
+   * amended after first locking.
+   */
+  private void promote() {
+    if(this.amended) {
+      synchronized(this.lock) {
+        if(this.amended) {
+          this.promoteLocked();
+        }
+      }
+    }
+  }
+
+  /**
+   * Records a missed attempt to grab a value from the immutable map. If the
+   * missed attempts exceeds the amount of elements in the map, the mutable
+   * map will then be promoted to the immutable map.
+   */
+  private void missLocked() {
+    this.misses++;
+
+    if(this.misses < this.mutable.size()) return;
+    this.promoteLocked();
+  }
+
+  /**
+   * Promotes the mutable map to the immutable map.
+   */
+  private void promoteLocked() {
+    this.immutable = this.mutable;
+    this.mutable = null;
+    this.amended = false;
+    this.misses = 0;
+  }
+
+  /**
+   * Creates a new mutable map from the immutable map and transfers the entries
+   * to it.
+   */
+  private void amendLocked() {
+    if(this.mutable != null) return;
+
+    final Map<K, ObjectReference> next = this.function.apply(this.immutable.size());
+    for(final Map.Entry<K, ObjectReference> entry : this.immutable.entrySet()) {
+      if(!entry.getValue().expunge()) {
+        next.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    this.mutable = next;
+  }
+
+  /* --- < Object Reference > ---------------------------------------------- */
+
+  /**
+   * Represents a value holder for sharing across nodes in the immutable and
+   * mutable maps, providing atomic updates for the underlying value.
+   */
+  @SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
+  public static final class ObjectReference {
+    private static final VarHandle VALUE;
+
+    static {
+      try {
+        final MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+        VALUE = lookup.findVarHandle(ObjectReference.class, "value", Object.class);
+      } catch(final Exception exception) {
+        throw new ExceptionInInitializerError(exception);
+      }
+    }
+
+    private @Nullable Object value;
+
+    private ObjectReference(final @Nullable Object value) {
+      this.value = value;
+    }
+
+    private boolean valueExists() {
+      final Object value;
+      return (value = ObjectReference.VALUE.getOpaque(this)) != null && value != ForwardingSyncMap.EXPUNGED;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <V> @Nullable V value() {
+      final Object value;
+      return (value = ObjectReference.VALUE.getAcquire(this)) != ForwardingSyncMap.EXPUNGED ? (V) value : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <V> V valueOr(final V defaultValue) {
+      final Object value;
+      return ((value = ObjectReference.VALUE.getAcquire(this)) != null && value != ForwardingSyncMap.EXPUNGED) ? (V) value : defaultValue;
+    }
+
+    private @Nullable Object get() {
+      return ObjectReference.VALUE.getAcquire(this);
+    }
+
+    private boolean expunge() {
+      return ObjectReference.VALUE.compareAndExchangeRelease(this, null, ForwardingSyncMap.EXPUNGED) == null;
+    }
+
+    private @Nullable Object compareAndExchange(final @Nullable Object expect, final @Nullable Object update) {
+      return ObjectReference.VALUE.compareAndExchangeRelease(this, expect, update);
+    }
+  }
+
+  /* --- < Iteration > ----------------------------------------------------- */
+
+  /**
+   * Represents a view of a map entry.
+   */
+  private final class MapEntry implements Map.Entry<K, V> {
+    private final K key;
+    private @Nullable V value;
+
+    private MapEntry(final K key, final @Nullable V value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    @Override
+    public K getKey() {
+      return this.key;
+    }
+
+    @Override
+    public @Nullable V getValue() {
+      return this.value;
+    }
+
+    @Override
+    public @Nullable V setValue(final V value) {
+      final V previous = ForwardingSyncMap.this.put(this.key, value);
+      this.value = value;
+      return previous;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(this.key, this.value);
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object other) {
+      if(this == other) return true;
+      if(!(other instanceof final Map.Entry<?, ?> that)) return false;
+      return Objects.equals(this.getKey(), that.getKey())
+        && Objects.equals(this.getValue(), that.getValue());
+    }
+
+    @Override
+    public String toString() {
+      return "ForwardingSyncMap.Entry{key=" + this.key + ", value=" + this.value + "}";
+    }
+  }
+
+  /**
+   * Represents a view of the map entries.
+   */
+  private final class EntrySet extends AbstractSet<Entry<K, V>> {
+    @Override
+    public int size() {
+      return ForwardingSyncMap.this.size();
+    }
+
+    @Override
+    public boolean contains(final @Nullable Object entry) {
+      if(!(entry instanceof final Map.Entry<?,?> that)) return false;
+      final V value = ForwardingSyncMap.this.get(that.getKey());
+      return value != null && Objects.equals(value, that.getValue());
+    }
+
+    @Override
+    public boolean remove(final @Nullable Object entry) {
+      if(!(entry instanceof final Map.Entry<?,?> that)) return false;
+      return ForwardingSyncMap.this.remove(that.getKey(), that.getValue());
+    }
+
+    @Override
+    public void clear() {
+      ForwardingSyncMap.this.clear();
+    }
+
+    @Override
+    public Iterator<Map.Entry<K, V>> iterator() {
+      ForwardingSyncMap.this.promote();
+      return new EntryIterator(ForwardingSyncMap.this.immutable.entrySet().iterator());
+    }
+  }
+
+  /**
+   * Represents an entry {@link Iterator} that traverses the entries in the
+   * given map.
+   */
+  private final class EntryIterator implements Iterator<Map.Entry<K, V>> {
+    private final Iterator<Map.Entry<K, ObjectReference>> backingIterator;
+    private Map.@Nullable Entry<K, V> next;
+    private Map.@Nullable Entry<K, V> current;
+
+    /* package */ EntryIterator(final Iterator<Map.Entry<K, ObjectReference>> backingIterator) {
+      this.backingIterator = backingIterator;
+      this.advance();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return this.next != null;
+    }
+
+    @Override
+    public Map.Entry<K, V> next() {
+      final Map.Entry<K, V> current;
+      if((current = this.next) == null) throw new NoSuchElementException();
+      this.current = current;
+      this.advance();
+      return current;
+    }
+
+    @Override
+    public void remove() {
+      final Map.Entry<K, V> current;
+      if((current = this.current) == null) throw new IllegalStateException();
+      this.current = null;
+      ForwardingSyncMap.this.remove(current.getKey(), current.getValue());
+    }
+
+    private void advance() {
+      this.next = null;
+      while(this.backingIterator.hasNext()) {
+        final Map.Entry<K, ObjectReference> entry;
+        final V value;
+
+        if((value = (entry = this.backingIterator.next()).getValue().value()) != null) {
+          this.next = new MapEntry(entry.getKey(), value);
+          return;
+        }
+      }
+    }
+  }
+}

--- a/collections/src/main/java/space/vectrix/sync/collections/ForwardingSyncMap.java
+++ b/collections/src/main/java/space/vectrix/sync/collections/ForwardingSyncMap.java
@@ -134,7 +134,7 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
    * @since 1.1.0
    */
   public ForwardingSyncMap(final IntFunction<Map<K, ObjectReference>> function, final int initialCapacity) {
-    if(initialCapacity < 0) throw new IllegalArgumentException("Initial capacity must be greater than 0");
+    if(initialCapacity < 0) throw new IllegalArgumentException("Initial capacity must be non-negative");
     this.function = function;
     this.immutable = this.function.apply(initialCapacity);
   }
@@ -380,7 +380,7 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
       if((reference = this.immutable.get(key)) != null) {
         previous = reference.get();
         for(; ; ) {
-          next = remappingFunction.apply(key, (V) previous);
+          next = remappingFunction.apply(key, previous == ForwardingSyncMap.EXPUNGED ? null : (V) previous);
 
           final Object witness = reference.compareAndExchange(previous, next);
           if(witness != previous) {
@@ -398,7 +398,7 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
       } else if(this.mutable != null && (reference = this.mutable.get(key)) != null) {
         previous = reference.get();
         for(; ; ) {
-          next = remappingFunction.apply(key, (V) previous);
+          next = remappingFunction.apply(key, previous == ForwardingSyncMap.EXPUNGED ? null : (V) previous);
 
           final Object witness = reference.compareAndExchange(previous, next);
           if(witness != previous) {
@@ -467,6 +467,7 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
 
           if(witness == ForwardingSyncMap.EXPUNGED) {
             this.mutable.put(key, reference);
+            return null;
           }
 
           break;
@@ -481,6 +482,10 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
             previous = witness;
             Thread.onSpinWait();
             continue;
+          }
+
+          if(witness == ForwardingSyncMap.EXPUNGED) {
+            return null;
           }
 
           break;
@@ -535,6 +540,7 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
 
           if(witness == ForwardingSyncMap.EXPUNGED) {
             this.mutable.put(key, reference);
+            return null;
           }
 
           break;
@@ -547,6 +553,10 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
             previous = witness;
             Thread.onSpinWait();
             continue;
+          }
+
+          if(witness == ForwardingSyncMap.EXPUNGED) {
+            return null;
           }
 
           break;
@@ -587,8 +597,7 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
     }
 
     synchronized(this.lock) {
-      if(this.immutable.get(key) == null && this.amended) {
-        reference = this.mutable.remove(key);
+      if(this.immutable.get(key) == null && this.amended && (reference = this.mutable.remove(key)) != null) {
         return reference.value();
       }
     }
@@ -620,8 +629,10 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
 
     synchronized(this.lock) {
       if(this.immutable.get(key) == null && this.amended && (reference = this.mutable.get(key)) != null) {
+        boolean removed = false;
+
         previous = reference.get();
-        while(previous != null) {
+        while(previous != null && previous != ForwardingSyncMap.EXPUNGED) {
           if(!Objects.equals(previous, value)) return false;
 
           final Object witness = reference.compareAndExchange(previous, null);
@@ -631,11 +642,12 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
             continue;
           }
 
+          removed = true;
           break;
         }
 
         this.mutable.remove(key);
-        return true;
+        return removed;
       }
     }
 
@@ -722,7 +734,8 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
 
   @Override
   public Set<Map.Entry<K, V>> entrySet() {
-    if(this.entrySet != null) return this.entrySet;
+    final EntrySet entrySet;
+    if((entrySet = this.entrySet) != null) return entrySet;
     return this.entrySet = new EntrySet();
   }
 
@@ -870,7 +883,7 @@ public class ForwardingSyncMap<K extends @Nullable Object, V> extends AbstractMa
 
     @Override
     public int hashCode() {
-      return Objects.hash(this.key, this.value);
+      return Objects.hashCode(this.key) ^ Objects.hashCode(this.value);
     }
 
     @Override

--- a/collections/src/test/java/space/vectrix/sync/collections/AbstractMapTest.java
+++ b/collections/src/test/java/space/vectrix/sync/collections/AbstractMapTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -139,12 +138,6 @@ public abstract class AbstractMapTest<K, V> {
     assertNull(map.get(this.key(10)), "Map should return the value null for key 10.");
   }
 
-  @Test
-  public void test_get_nullKey() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.get(null), "Map should throw exception when given a null key.");
-  }
-
   // getOrDefault
 
   @Test
@@ -158,13 +151,6 @@ public abstract class AbstractMapTest<K, V> {
     final Map<K, V> map = this.populate(this.createMap(), 5);
     assertEquals(this.value(3), map.getOrDefault(this.key(3), this.value(5)), "Map should return the value 3 for key 3.");
     assertEquals(this.value(4), map.getOrDefault(this.key(4), this.value(5)), "Map should return the value 3 for key 3.");
-  }
-
-  @Test
-  public void test_getOrDefault_nullKey() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.getOrDefault(this.key(3), null), "Map should throw exception when given a null default value.");
-    assertThrows(NullPointerException.class, () -> map.getOrDefault(null, this.value(3)), "Map should throw exception when given a null key.");
   }
 
   // computeIfAbsent
@@ -183,12 +169,6 @@ public abstract class AbstractMapTest<K, V> {
     assertEquals(this.value(3), map.computeIfAbsent(this.key(3), key -> this.value(5)), "Map should return the value 3 for key 3.");
     assertEquals(this.value(3), map.get(this.key(3)), "Map should return the value 3 for key 3.");
     assertEquals(5, map.size(), "Map should be of size 5.");
-  }
-
-  @Test
-  public void test_computeIfAbsent_nullKey() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.computeIfAbsent(null, key -> this.value(0)), "Map should throw exception when given a null key.");
   }
 
   @Test
@@ -226,12 +206,6 @@ public abstract class AbstractMapTest<K, V> {
   }
 
   @Test
-  public void test_computeIfPresent_nullKey() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.computeIfPresent(null, (key, previousValue) -> this.value(0)), "Map should throw exception when given a null key.");
-  }
-
-  @Test
   public void test_computeIfPresent_fullNullValue() {
     final Map<K, V> map = this.populate(this.createMap(), 5);
     assertNull(map.computeIfPresent(this.key(3), (key, previousValue) -> null), "Map should return null for key 3.");
@@ -263,12 +237,6 @@ public abstract class AbstractMapTest<K, V> {
     assertEquals(this.value(5), map.compute(this.key(3), (key, previousValue) -> this.value(5)), "Map should return the value 5 for key 3.");
     assertEquals(this.value(5), map.get(this.key(3)), "Map should return the value 5 for key 3.");
     assertEquals(5, map.size(), "Map should be of size 5.");
-  }
-
-  @Test
-  public void test_compute_nullKey() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.compute(null, (key, previousValue) -> this.value(0)), "Map should throw exception when given a null key.");
   }
 
   @Test
@@ -305,13 +273,6 @@ public abstract class AbstractMapTest<K, V> {
     assertEquals(5, map.size(), "Map should be of size 5.");
   }
 
-  @Test
-  public void test_putIfAbsent_nullKeyValue() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.putIfAbsent(null, this.value(3)), "Map should throw exception when given a null key.");
-    assertThrows(NullPointerException.class, () -> map.putIfAbsent(this.key(3), null), "Map should throw exception when given a null value.");
-  }
-
   // put
 
   @Test
@@ -330,13 +291,6 @@ public abstract class AbstractMapTest<K, V> {
     assertEquals(5, map.size(), "Map should be of size 5.");
   }
 
-  @Test
-  public void test_put_nullKeyValue() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.put(null, this.value(3)), "Map should throw exception when given a null key.");
-    assertThrows(NullPointerException.class, () -> map.put(this.key(3), null), "Map should throw exception when given a null value.");
-  }
-
   // removeKey
 
   @Test
@@ -353,12 +307,6 @@ public abstract class AbstractMapTest<K, V> {
     assertEquals(this.value(3), map.remove(this.key(3)), "Map should return value 3 for key 3.");
     assertNull(map.get(this.key(3)), "Map should return null for key 3.");
     assertEquals(4, map.size(), "Map should be of size 4.");
-  }
-
-  @Test
-  public void test_removeKey_nullKey() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.remove(null), "Map should throw exception when given a null key.");
   }
 
   // removeKeyValue
@@ -383,13 +331,6 @@ public abstract class AbstractMapTest<K, V> {
     assertEquals(4, map.size(), "Map should be of size 4.");
   }
 
-  @Test
-  public void test_removeKeyValue_nullKeyValue() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.remove(null, this.value(3)), "Map should throw exception when given a null key.");
-    assertThrows(NullPointerException.class, () -> map.remove(this.key(3), null), "Map should throw exception when given a null value.");
-  }
-
   // replaceKey
 
   @Test
@@ -406,13 +347,6 @@ public abstract class AbstractMapTest<K, V> {
     assertEquals(this.value(3), map.replace(this.key(3), this.value(5)), "Map should return value 3 for key 3 and value 5.");
     assertEquals(this.value(5), map.get(this.key(3)), "Map should return value 5 for key 3.");
     assertEquals(5, map.size(), "Map should be of size 5.");
-  }
-
-  @Test
-  public void test_replaceKey_nullKeyValue() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.remove(null, this.value(3)), "Map should throw exception when given a null key.");
-    assertThrows(NullPointerException.class, () -> map.remove(this.key(3), null), "Map should throw exception when given a null value.");
   }
 
   // replaceKeyValue
@@ -435,13 +369,6 @@ public abstract class AbstractMapTest<K, V> {
     assertTrue(map.replace(this.key(3), this.value(3), this.value(5)), "Map should return true for key 3, value 3 and value 5.");
     assertEquals(this.value(5), map.get(this.key(3)), "Map should return value 5 for key 3.");
     assertEquals(5, map.size(), "Map should be of size 5.");
-  }
-
-  @Test
-  public void test_replaceKeyValue_nullKeyValue() {
-    final Map<K, V> map = this.createMap();
-    assertThrows(NullPointerException.class, () -> map.replace(null, this.value(3), this.value(5)), "Map should throw exception when given a null key.");
-    assertThrows(NullPointerException.class, () -> map.replace(this.key(3), null, null), "Map should throw exception when given a null value.");
   }
 
   // forEach

--- a/collections/src/test/java/space/vectrix/sync/collections/AbstractNullMapTest.java
+++ b/collections/src/test/java/space/vectrix/sync/collections/AbstractNullMapTest.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of sync, licensed under the MIT License.
+ *
+ * Copyright (c) 2025 vectrix.space
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package space.vectrix.sync.collections;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public abstract class AbstractNullMapTest<K, V> extends AbstractMapTest<K, V> {
+  // get
+
+  @Test
+  public void test_get_nullKey() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.get(null), "Map should throw exception when given a null key.");
+  }
+
+  // getOrDefault
+
+  @Test
+  public void test_getOrDefault_nullKey() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.getOrDefault(this.key(3), null), "Map should throw exception when given a null default value.");
+    assertThrows(NullPointerException.class, () -> map.getOrDefault(null, this.value(3)), "Map should throw exception when given a null key.");
+  }
+
+  // computeIfAbsent
+
+  @Test
+  public void test_computeIfAbsent_nullKey() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.computeIfAbsent(null, key -> this.value(0)), "Map should throw exception when given a null key.");
+  }
+
+  // computeIfPresent
+
+  @Test
+  public void test_computeIfPresent_nullKey() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.computeIfPresent(null, (key, previousValue) -> this.value(0)), "Map should throw exception when given a null key.");
+  }
+
+  // compute
+
+  @Test
+  public void test_compute_nullKey() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.compute(null, (key, previousValue) -> this.value(0)), "Map should throw exception when given a null key.");
+  }
+
+  // putIfAbsent
+
+  @Test
+  public void test_putIfAbsent_nullKeyValue() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.putIfAbsent(null, this.value(3)), "Map should throw exception when given a null key.");
+    assertThrows(NullPointerException.class, () -> map.putIfAbsent(this.key(3), null), "Map should throw exception when given a null value.");
+  }
+
+  // put
+
+  @Test
+  public void test_put_nullKeyValue() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.put(null, this.value(3)), "Map should throw exception when given a null key.");
+    assertThrows(NullPointerException.class, () -> map.put(this.key(3), null), "Map should throw exception when given a null value.");
+  }
+
+  // removeKey
+
+  @Test
+  public void test_removeKey_nullKey() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.remove(null), "Map should throw exception when given a null key.");
+  }
+
+  // removeKeyValue
+
+  @Test
+  public void test_removeKeyValue_nullKeyValue() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.remove(null, this.value(3)), "Map should throw exception when given a null key.");
+    assertThrows(NullPointerException.class, () -> map.remove(this.key(3), null), "Map should throw exception when given a null value.");
+  }
+
+  // replaceKey
+
+  @Test
+  public void test_replaceKey_nullKeyValue() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.remove(null, this.value(3)), "Map should throw exception when given a null key.");
+    assertThrows(NullPointerException.class, () -> map.remove(this.key(3), null), "Map should throw exception when given a null value.");
+  }
+
+  // replaceKeyValue
+
+  @Test
+  public void test_replaceKeyValue_nullKeyValue() {
+    final Map<K, V> map = this.createMap();
+    assertThrows(NullPointerException.class, () -> map.replace(null, this.value(3), this.value(5)), "Map should throw exception when given a null key.");
+    assertThrows(NullPointerException.class, () -> map.replace(this.key(3), null, null), "Map should throw exception when given a null value.");
+  }
+}

--- a/collections/src/test/java/space/vectrix/sync/collections/ForwardingSyncMapTest.java
+++ b/collections/src/test/java/space/vectrix/sync/collections/ForwardingSyncMapTest.java
@@ -23,17 +23,18 @@
  */
 package space.vectrix.sync.collections;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Provides {@link BucketSyncMap} specific test data for {@link AbstractMapTest}.
+ * Provides {@link ForwardingSyncMap} specific test data for {@link AbstractMapTest}.
  *
  * @since 1.0.0
  */
-public class BucketSyncMapTest extends AbstractNullMapTest<String, String> {
+public class ForwardingSyncMapTest extends AbstractMapTest<String, String> {
   @Override
   protected Map<String, String> createMap() {
-    return new BucketSyncMap<>();
+    return new ForwardingSyncMap<>(HashMap::new);
   }
 
   @Override


### PR DESCRIPTION
Reimplements the original `SyncMap` wrapper from [Flare](https://github.com/vectrix-space/flare).