### PR TITLE
remove additional hash checks from fastutil implementation

### DIFF
--- a/collections-fastutil/benchmarks.md
+++ b/collections-fastutil/benchmarks.md
@@ -13,63 +13,63 @@ The following results were recorded on an _M4 Macbook Pro_, using 8 threads and
 100,000 entries for each benchmark:
 
 - `Int2ObjectBucketSyncMap` **get()** speed is...
-  - 50x faster than `Int2ObjectMaps#synchronize()` for an empty map.
-  - 50x faster than `Int2ObjectMaps#synchronize()` for a presized empty map.
-  - 75x faster than `Int2ObjectMaps#synchronize()` for a full map.
+  - +65x to +50x difference in comparison to `Int2ObjectMaps#synchronize()` for an empty map.
+  - +70x to +60x difference in comparison to `Int2ObjectMaps#synchronize()` for a presized empty map.
+  - +115x to +110x difference in comparison to `Int2ObjectMaps#synchronize()` for a full map.
 
 - `Int2ObjectBucketSyncMap` **put()** speed is...
-  - 15x faster than `Int2ObjectMaps#synchronize()` for an empty map.
-  - 15x faster than `Int2ObjectMaps#synchronize()` for a presized empty map.
-  - 25x faster than `Int2ObjectMaps#synchronize()` for a full map.
+  - +15x difference in comparison to `Int2ObjectMaps#synchronize()` for an empty map.
+  - +15x difference in comparison to `Int2ObjectMaps#synchronize()` for a presized empty map.
+  - +25x to +15x difference in comparison to `Int2ObjectMaps#synchronize()` for a full map.
 
 - `Int2ObjectBucketSyncMap` **put()** then **get()** speed is...
-  - 35x faster than `Int2ObjectMaps#synchronize()` for an empty map.
-  - 40x faster than `Int2ObjectMaps#synchronize()` for a presized empty map.
-  - 35x faster than `Int2ObjectMaps#synchronize()` for a full map.
+  - +35x difference in comparison to `Int2ObjectMaps#synchronize()` for an empty map.
+  - +35x difference in comparison to `Int2ObjectMaps#synchronize()` for a presized empty map.
+  - +35x to +30x difference in comparison to `Int2ObjectMaps#synchronize()` for a full map.
 
 ### Results
 
 ```txt
-Benchmark                                  (implementation)       (mode)  (prime)  (readPercentage)  (size)   Mode  Cnt  Score   Error   Units
-Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap         none    false                50  100000  thrpt    5  1.680 ± 0.001  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap         none     true                50  100000  thrpt    5  1.680 ± 0.001  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap      presize    false                50  100000  thrpt    5  1.681 ± 0.001  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap      presize     true                50  100000  thrpt    5  1.681 ± 0.001  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap  prepopulate    false                50  100000  thrpt    5  1.637 ± 0.005  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap  prepopulate     true                50  100000  thrpt    5  1.634 ± 0.002  ops/ns
+Benchmark                                  (implementation)       (mode)  (prime)  (readPercentage)  (size)   Mode  Cnt  Score    Error   Units
+Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap         none    false                50  100000  thrpt    5  1.681 ±  0.001  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap         none     true                50  100000  thrpt    5  1.680 ±  0.001  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap      presize    false                50  100000  thrpt    5  1.681 ±  0.002  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap      presize     true                50  100000  thrpt    5  1.680 ±  0.001  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap  prepopulate    false                50  100000  thrpt    5  2.472 ±  0.009  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only     BucketSyncMap  prepopulate     true                50  100000  thrpt    5  2.471 ±  0.008  ops/ns
 
-Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.041 ± 0.074  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.039 ± 0.068  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.038 ± 0.077  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.038 ± 0.075  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.023 ± 0.035  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.021 ± 0.016  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.026 ±  0.006  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.033 ±  0.059  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.025 ±  0.002  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.027 ±  0.006  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.022 ±  0.002  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.023 ±  0.010  ops/ns
 
-Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap         none    false                50  100000  thrpt    5  0.632 ± 0.058  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap         none     true                50  100000  thrpt    5  0.639 ± 0.061  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap      presize    false                50  100000  thrpt    5  0.638 ± 0.031  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap      presize     true                50  100000  thrpt    5  0.665 ± 0.278  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap  prepopulate    false                50  100000  thrpt    5  0.645 ± 0.068  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap  prepopulate     true                50  100000  thrpt    5  0.635 ± 0.083  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap         none    false                50  100000  thrpt    5  0.626 ±  0.079  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap         none     true                50  100000  thrpt    5  0.630 ±  0.060  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap      presize    false                50  100000  thrpt    5  0.630 ±  0.033  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap      presize     true                50  100000  thrpt    5  0.649 ±  0.187  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap  prepopulate    false                50  100000  thrpt    5  0.630 ±  0.023  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put      BucketSyncMap  prepopulate     true                50  100000  thrpt    5  0.640 ±  0.035  ops/ns
 
-Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap         none    false                50  100000  thrpt    5  0.018 ± 0.010  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap         none     true                50  100000  thrpt    5  0.019 ± 0.013  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap      presize    false                50  100000  thrpt    5  0.020 ± 0.002  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap      presize     true                50  100000  thrpt    5  0.015 ± 0.010  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.017 ± 0.014  ops/ns
-Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.019 ± 0.010  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap         none    false                50  100000  thrpt    5  0.018 ±  0.013  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap         none     true                50  100000  thrpt    5  0.018 ±  0.014  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap      presize    false                50  100000  thrpt    5  0.020 ±  0.013  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap      presize     true                50  100000  thrpt    5  0.018 ±  0.016  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.021 ±  0.003  ops/ns
+Int2ObjectBucketSyncMapBenchmark.get_put    SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.020 ±  0.003  ops/ns
 
-Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap         none    false                50  100000  thrpt    5  0.303 ± 0.027  ops/ns
-Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap         none     true                50  100000  thrpt    5  0.309 ± 0.062  ops/ns
-Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap      presize    false                50  100000  thrpt    5  0.297 ± 0.028  ops/ns
-Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap      presize     true                50  100000  thrpt    5  0.309 ± 0.027  ops/ns
-Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap  prepopulate    false                50  100000  thrpt    5  0.288 ± 0.041  ops/ns
-Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap  prepopulate     true                50  100000  thrpt    5  0.508 ± 0.036  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap         none    false                50  100000  thrpt    5  0.282 ±  0.036  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap         none     true                50  100000  thrpt    5  0.314 ±  0.115  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap      presize    false                50  100000  thrpt    5  0.298 ±  0.051  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap      presize     true                50  100000  thrpt    5  0.312 ±  0.073  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap  prepopulate    false                50  100000  thrpt    5  0.282 ±  0.013  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only     BucketSyncMap  prepopulate     true                50  100000  thrpt    5  0.521 ±  0.062  ops/ns
 
-Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.022 ± 0.002  ops/ns
-Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.022 ± 0.008  ops/ns
-Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.026 ± 0.026  ops/ns
-Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.023 ± 0.011  ops/ns
-Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.026 ± 0.028  ops/ns
-Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.022 ± 0.002  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap         none    false                50  100000  thrpt    5  0.020 ±  0.006  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap         none     true                50  100000  thrpt    5  0.020 ±  0.005  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap      presize    false                50  100000  thrpt    5  0.021 ±  0.005  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap      presize     true                50  100000  thrpt    5  0.022 ±  0.001  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap  prepopulate    false                50  100000  thrpt    5  0.021 ±  0.001  ops/ns
+Int2ObjectBucketSyncMapBenchmark.put_only   SynchronizedMap  prepopulate     true                50  100000  thrpt    5  0.021 ±  0.001  ops/ns
 ```

--- a/collections-fastutil/src/main/java-templates/space/vectrix/sync/collections/fastutil/{{key}}2ObjectBucketSyncMap.java.peb
+++ b/collections-fastutil/src/main/java-templates/space/vectrix/sync/collections/fastutil/{{key}}2ObjectBucketSyncMap.java.peb
@@ -405,12 +405,12 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
     final int hash = this.spreadFunction.spread(key);
 
     if(length > 0 && (node = {{ key }}2ObjectBucketSyncMap.getNode(table, (length - 1) & hash)) != null) {
-      if(node.hash == hash && node.key == key) {
+      if(node.key == key) {
         return node.referencePlain().valueExists();
       }
 
       while((node = node.nextPlain()) != null) {
-        if(node.hash == hash && node.key == key) {
+        if(node.key == key) {
           return node.referencePlain().valueExists();
         }
       }
@@ -419,13 +419,12 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
     if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
       boolean exists = false;
       retry: if((node = {{ key }}2ObjectBucketSyncMap.getNode(table, (length - 1) & hash)) != null) {
-        final int nodeHash;
-        if((nodeHash = node.hash) == hash) {
+        if(node.hash >= 0) {
           if(node.key == key) {
             exists = node.reference().valueExists();
             break retry;
           }
-        } else if(nodeHash < 0) {
+        } else {
           final Node nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             exists = nextNode.reference().valueExists();
@@ -434,7 +433,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         }
 
         while((node = node.next()) != null) {
-          if(node.hash == hash && node.key == key) {
+          if(node.key == key) {
             exists = node.reference().valueExists();
             break retry;
           }
@@ -466,12 +465,12 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
     final int hash = this.spreadFunction.spread(key);
 
     if(length > 0 && (node = {{ key }}2ObjectBucketSyncMap.getNode(table, (length - 1) & hash)) != null) {
-      if(node.hash == hash && node.key == key) {
+      if(node.key == key) {
         return node.referencePlain().value();
       }
 
       while((node = node.nextPlain()) != null) {
-        if(node.hash == hash && node.key == key) {
+        if(node.key == key) {
           return node.referencePlain().value();
         }
       }
@@ -480,13 +479,12 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
     if(this.amended && (table = this.mutableTable) != null && (length = table.length) > 0) {
       V value = null;
       retry: if((node = {{ key }}2ObjectBucketSyncMap.getNode(table, (length - 1) & hash)) != null) {
-        final int nodeHash;
-        if((nodeHash = node.hash) == hash) {
+        if(node.hash >= 0) {
           if(node.key == key) {
             value = node.reference().value();
             break retry;
           }
-        } else if(nodeHash < 0) {
+        } else {
           final Node nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             value = nextNode.reference().value();
@@ -495,7 +493,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         }
 
         while((node = node.next()) != null) {
-          if(node.hash == hash && node.key == key) {
+          if(node.key == key) {
             value = node.reference().value();
             break retry;
           }
@@ -529,12 +527,12 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
     final int hash = this.spreadFunction.spread(key);
 
     if(length > 0 && (node = {{ key }}2ObjectBucketSyncMap.getNode(table, (length - 1) & hash)) != null) {
-      if(node.hash == hash && node.key == key) {
+      if(node.key == key) {
         return node.referencePlain().valueOr(defaultValue);
       }
 
       while((node = node.nextPlain()) != null) {
-        if(node.hash == hash && node.key == key) {
+        if(node.key == key) {
           return node.referencePlain().valueOr(defaultValue);
         }
       }
@@ -544,12 +542,12 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
       V value = defaultValue;
       retry: if((node = {{ key }}2ObjectBucketSyncMap.getNode(table, (length - 1) & hash)) != null) {
         final int nodeHash;
-        if((nodeHash = node.hash) == hash) {
+        if(node.hash >= 0) {
           if(node.key == key) {
             value = node.reference().valueOr(defaultValue);
             break retry;
           }
-        } else if(nodeHash < 0) {
+        } else {
           final Node nextNode;
           if((nextNode = node.find(hash, key)) != null) {
             value = nextNode.reference().valueOr(defaultValue);
@@ -558,7 +556,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         }
 
         while((node = node.next()) != null) {
-          if(node.hash == hash && node.key == key) {
+          if(node.key == key) {
             value = node.reference().valueOr(defaultValue);
             break retry;
           }
@@ -605,7 +603,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         // node is present and the value is null or expunged.
         node = {{ key }}2ObjectBucketSyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
-          if(node.hash != hash || node.key != key) {
+          if(node.key != key) {
             node = node.next();
             continue;
           }
@@ -656,7 +654,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
@@ -727,7 +725,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         // node is present and the value is null or expunged.
         node = {{ key }}2ObjectBucketSyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
-          if(node.hash != hash || node.key != key) {
+          if(node.key != key) {
             node = node.next();
             continue;
           }
@@ -778,7 +776,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
@@ -869,7 +867,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         // node is present.
         node = {{ key }}2ObjectBucketSyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
-          if(node.hash != hash || node.key != key) {
+          if(node.key != key) {
             node = node.next();
             continue;
           }
@@ -903,7 +901,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(mutable, index) == node) {
             for(Node previousNode = null; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
@@ -980,7 +978,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         // node is present.
         node = {{ key }}2ObjectBucketSyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
-          if(node.hash != hash || node.key != key) {
+          if(node.key != key) {
             node = node.next();
             continue;
           }
@@ -1038,7 +1036,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(mutable, index) == node) {
             for(Node previousNode = null; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
@@ -1054,7 +1052,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
 
                   if(next != null && (witness == null || witness == {{ key }}2ObjectBucketSyncMap.EXPUNGED)) {
                     count = 1L;
-                  } else if(next == null && (witness != null && witness != {{ key }}2ObjectBucketSyncMap.EXPUNGED)) {
+                  } else if(next == null) {
                     if(previousNode != null) {
                       previousNode.next(node.nextPlain());
                     } else {
@@ -1109,7 +1107,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         // node is present and the value is null or expunged.
         node = {{ key }}2ObjectBucketSyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
-          if(node.hash != hash || node.key != key) {
+          if(node.key != key) {
             node = node.next();
             continue;
           }
@@ -1154,7 +1152,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
@@ -1206,7 +1204,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         // node is present.
         node = {{ key }}2ObjectBucketSyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
-          if(node.hash != hash || node.key != key) {
+          if(node.key != key) {
             node = node.next();
             continue;
           }
@@ -1251,7 +1249,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
@@ -1304,7 +1302,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(table, index) == node) {
             for(; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 node.reference(reference);
                 return;
               }
@@ -1349,7 +1347,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         // node is present.
         node = {{ key }}2ObjectBucketSyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
-          if(node.hash != hash || node.key != key) {
+          if(node.key != key) {
             node = node.next();
             continue;
           }
@@ -1378,7 +1376,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(mutable, index) == node) {
             for(Node previousNode = null; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object current = reference.get();
                 for(; ; ) {
@@ -1442,7 +1440,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         // node is present.
         node = {{ key }}2ObjectBucketSyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
-          if(node.hash != hash || node.key != key) {
+          if(node.key != key) {
             node = node.next();
             continue;
           }
@@ -1472,7 +1470,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(mutable, index) == node) {
             for(Node previousNode = null; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object previous = reference.get();
                 for(; ; ) {
@@ -1540,7 +1538,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         // node is present.
         node = {{ key }}2ObjectBucketSyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
-          if(node.hash != hash || node.key != key) {
+          if(node.key != key) {
             node = node.next();
             continue;
           }
@@ -1569,7 +1567,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object current = reference.get();
                 for(; ; ) {
@@ -1627,7 +1625,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         // node is present.
         node = {{ key }}2ObjectBucketSyncMap.getNode(immutable, (length - 1) & hash);
         while(node != null) {
-          if(node.hash != hash || node.key != key) {
+          if(node.key != key) {
             node = node.next();
             continue;
           }
@@ -1657,7 +1655,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
         synchronized(node) {
           if({{ key }}2ObjectBucketSyncMap.getNodePlain(mutable, index) == node) {
             for(; ; ) {
-              if(node.hash == hash && node.key == key) {
+              if(node.key == key) {
                 final ObjectReference reference = node.referencePlain();
                 Object current = reference.get();
                 for(; ; ) {
@@ -2520,7 +2518,7 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
       Node node = this;
 
       do {
-        if(node.hash == hash && node.key == key) return node;
+        if(node.key == key) return node;
       } while((node = node.next()) != null);
 
       return null;
@@ -2545,20 +2543,18 @@ public class {{ key }}2ObjectBucketSyncMap<V> extends Abstract{{ key }}2ObjectMa
       int length;
 
       Node node;
-      int nodeHash;
-
       while((length = table.length) > 0) {
         if((node = {{ key }}2ObjectBucketSyncMap.getNode(table, (length - 1) & hash)) == null) {
           return null;
-        } else if((nodeHash = node.hash) == {{ key }}2ObjectBucketSyncMap.NODE_MOVED) {
+        } else if(node.hash == {{ key }}2ObjectBucketSyncMap.NODE_MOVED) {
           table = ((ForwardingNode) node).nextTable;
         } else {
-          if(nodeHash == hash && node.key == key) {
+          if(node.key == key) {
             return node;
           }
 
           while((node = node.next()) != null) {
-            if(node.hash == hash && node.key == key) {
+            if(node.key == key) {
               return node;
             }
           }


### PR DESCRIPTION
These additional hash checks do not need to be done on the primitive keys and thus can be removed.